### PR TITLE
Keep whatever headers passed into runEvent

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -61,10 +61,8 @@ const addAuthData = (event, bundle, convertedBundle) => {
     convertedBundle.request.auth = [username, password];
   }
 
-  const headers = _.get(bundle, ['request', 'headers']);
-  if (!_.isEmpty(headers)) {
-    _.extend(convertedBundle.request.headers, headers);
-  }
+  const headers = _.get(bundle, ['request', 'headers'], {});
+  _.extend(convertedBundle.request.headers, headers);
 
   // OAuth2 specific
   if (event.name.startsWith('auth.oauth2')) {

--- a/bundle.js
+++ b/bundle.js
@@ -61,6 +61,11 @@ const addAuthData = (event, bundle, convertedBundle) => {
     convertedBundle.request.auth = [username, password];
   }
 
+  const headers = _.get(bundle, ['request', 'headers']);
+  if (!_.isEmpty(headers)) {
+    _.extend(convertedBundle.request.headers, headers);
+  }
+
   // OAuth2 specific
   if (event.name.startsWith('auth.oauth2')) {
     convertedBundle.oauth_data = {


### PR DESCRIPTION
Keep the headers when converting `bundle.request` from CLI to WB scripting.

This is to address the need to run middlewares on the app level. Refer to zapier/zapier-platform-cli#271.