### PR TITLE
Keep request.params passed into runEvent

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -64,6 +64,9 @@ const addAuthData = (event, bundle, convertedBundle) => {
   const headers = _.get(bundle, ['request', 'headers'], {});
   _.extend(convertedBundle.request.headers, headers);
 
+  const params = _.get(bundle, ['request', 'params'], {});
+  _.extend(convertedBundle.request.params, params);
+
   // OAuth2 specific
   if (event.name.startsWith('auth.oauth2')) {
     convertedBundle.oauth_data = {


### PR DESCRIPTION
Keep `request.params` when converting `bundle.request` from CLI to WB scripting. Almost the identical to PR #1, but for `request.params`.

This is to address the need to run middlewares on the app level. Refer to zapier/zapier-platform-cli#271.