### PR TITLE
Legacy Scripting: Add support for session auth

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,11 +131,52 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
       return undefined;
     });
 
+  const runSessionAuth = bundle => {
+    return runEvent({ name: 'auth.session' }, zobj, bundle).then(
+      sessionData => {
+        // WB apps in scripting's get_session_info() allowed you to return any
+        // object and that would be added to the authData, but CLI apps require
+        // you to specifically define those. That means that if you return more
+        // than one key from your scripting's get_session_info(), Zapier staff
+        // will need to manually set sessionConfig.legacyProperties.sessionKeyKey
+        // for the dev to select a value from the object returned from
+        // get_session_info().
+
+        let sessionKey;
+        const keys = Object.keys(sessionData);
+        if (_.isEmpty(keys)) {
+          throw new Error('Empty result from get_session_info()');
+        } else if (keys.length === 1) {
+          sessionKey = sessionData[keys[0]];
+        } else {
+          const sessionKeyKey = _.get(
+            app,
+            'authentication.sessionConfig.legacyProperties.sessionKeyKey'
+          );
+          if (!sessionKeyKey) {
+            throw new Error(
+              'Must configure sessionKeyKey if get_session_info() returns more than one item'
+            );
+          }
+          if (keys.indexOf(sessionKeyKey) < 0) {
+            throw new Error(`sessionKeyKey must be in (${keys})`);
+          }
+          sessionKey = sessionData[sessionKeyKey];
+        }
+
+        return { sessionKey };
+      }
+    );
+  };
+
   const runTrigger = (bundle, key) => {
     let promise = null;
     const funcs = [];
 
-    bundle._legacyUrl = _.get(app, `triggers.${key}.operation.legacyProps.url`);
+    bundle._legacyUrl = _.get(
+      app,
+      `triggers.${key}.operation.legacyProperties.url`
+    );
     bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
 
     const fullMethod = Zap[`${key}_poll`];
@@ -181,8 +222,11 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
   // z.legacyScripting.run() method that we can run legacy scripting easily
   // like z.legacyScripting.run(bundle, 'trigger', 'KEY') in CLI.
   const run = (bundle, typeOf, key) => {
-    if (typeOf === 'trigger') {
-      return runTrigger(bundle, key);
+    switch (typeOf) {
+      case 'auth.session':
+        return runSessionAuth(bundle);
+      case 'trigger':
+        return runTrigger(bundle, key);
     }
 
     // TODO: auth, create, and search


### PR DESCRIPTION
Adds support for running `get_session_info()`scripting method with `z.legacyScripting.run(bundle, 'auth.session')`. Test can be found [here](https://github.com/zapier/zapier-platform-core/pull/86/files#diff-df07f23506acd426532e246a617346c6R36).