### PR TITLE
Ability to run OAuth2 scripting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "6.10.3"
-  - "7"
-  - "8"
+  - "8.10.0"
+  - "10"
 before_script: npm install -g zapier-platform-cli
 script: npm run ci-test
 notifications:
@@ -13,5 +12,5 @@ deploy:
   api_key: $NPM_TOKEN
   on:
     tags: true
-    node: "6.10.3"
+    node: "8.10.0"
   skip_cleanup: true

--- a/bundle.js
+++ b/bundle.js
@@ -61,11 +61,16 @@ const addAuthData = (event, bundle, convertedBundle) => {
     convertedBundle.request.auth = [username, password];
   }
 
-  const headers = _.get(bundle, ['request', 'headers'], {});
+  const headers = _.get(bundle, 'request.headers', {});
   _.extend(convertedBundle.request.headers, headers);
 
-  const params = _.get(bundle, ['request', 'params'], {});
+  const params = _.get(bundle, 'request.params', {});
   _.extend(convertedBundle.request.params, params);
+
+  const body = _.get(bundle, 'request.body');
+  if (body) {
+    convertedBundle.request.data = body;
+  }
 
   // OAuth2 specific
   if (event.name.startsWith('auth.oauth2')) {

--- a/bundle.js
+++ b/bundle.js
@@ -11,8 +11,12 @@ const unflattenObject = (data, separator = '__') => {
 
   const keys = Object.keys(data);
 
-  _.each(keys, (key) => {
-    if (key.includes(separator) && !key.startsWith(separator) && !key.endsWith(separator)) {
+  _.each(keys, key => {
+    if (
+      key.includes(separator) &&
+      !key.startsWith(separator) &&
+      !key.endsWith(separator)
+    ) {
       const value = data[key];
       const keyParts = key.split(separator, MAX_KEY_PARTS);
 
@@ -26,7 +30,7 @@ const unflattenObject = (data, separator = '__') => {
         currentProp = currentProp[keyParts[i]];
       }
 
-      previousProp[keyParts[(i - 1)]] = value;
+      previousProp[keyParts[i - 1]] = value;
 
       delete data[key];
     }
@@ -35,13 +39,13 @@ const unflattenObject = (data, separator = '__') => {
   return data;
 };
 
-const convertToQueryString = (object) => {
+const convertToQueryString = object => {
   if (!object) {
     return '';
   }
 
   const objectKeys = Object.keys(object);
-  const queryStringItems = _.map(objectKeys, (key) => `${key}=${object[key]}`);
+  const queryStringItems = _.map(objectKeys, key => `${key}=${object[key]}`);
 
   return queryStringItems.join('&');
 };
@@ -52,10 +56,7 @@ const convertToQueryString = (object) => {
 
 const addAuthData = (event, bundle, convertedBundle) => {
   // Get authData only for basic auth here, to include in the request
-  const {
-    username,
-    password,
-  } = _.get(bundle, 'authData', {});
+  const { username, password } = _.get(bundle, 'authData', {});
 
   if (username && password) {
     convertedBundle.request.auth = [username, password];
@@ -76,7 +77,7 @@ const addAuthData = (event, bundle, convertedBundle) => {
   if (event.name.startsWith('auth.oauth2')) {
     convertedBundle.oauth_data = {
       client_id: process.env.CLIENT_ID,
-      client_secret: process.env.CLIENT_SECRET,
+      client_secret: process.env.CLIENT_SECRET
     };
     convertedBundle.load = _.get(bundle, 'inputData', {});
   }
@@ -87,7 +88,8 @@ const addInputData = (event, bundle, convertedBundle) => {
     convertedBundle.test_result = bundle.inputData;
   } else if (event.name.startsWith('trigger.')) {
     convertedBundle.trigger_fields = bundle.inputData;
-    convertedBundle.trigger_fields_raw = bundle.inputDataRaw || bundle.inputData;
+    convertedBundle.trigger_fields_raw =
+      bundle.inputDataRaw || bundle.inputData;
   } else if (event.name.startsWith('create.')) {
     convertedBundle.action_fields = bundle.inputData;
     convertedBundle.action_fields_full = bundle.inputData;
@@ -108,7 +110,9 @@ const addHookData = (event, bundle, convertedBundle) => {
     convertedBundle.cleaned_request = bundle.cleanedRequest;
 
     if (!convertedBundle.request.querystring) {
-      convertedBundle.request.querystring = convertToQueryString(convertedBundle.request.params);
+      convertedBundle.request.querystring = convertToQueryString(
+        convertedBundle.request.params
+      );
     }
     if (!convertedBundle.request.content) {
       convertedBundle.request.content = convertedBundle.request.data;
@@ -137,9 +141,10 @@ const addResponse = (event, bundle, convertedBundle) => {
 const bundleConverter = (bundle, event) => {
   let method = 'GET';
 
-  if (event.name.startsWith('create')
-    || event.name.startsWith('auth.oauth2')
-    || event.name.startsWith('trigger.hook.subscribe')
+  if (
+    event.name.startsWith('create') ||
+    event.name.startsWith('auth.oauth2') ||
+    event.name.startsWith('trigger.hook.subscribe')
   ) {
     method = 'POST';
   }
@@ -147,19 +152,23 @@ const bundleConverter = (bundle, event) => {
   const convertedBundle = {
     request: {
       method,
-      url: _.get(bundle, '_legacyUrl', ''),
+      url: _.get(bundle, '_legacyUrl', '') || _.get(bundle, 'request.url', ''),
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       },
-      params: event.name.startsWith('create') ? {} : _.get(bundle, 'inputData', {}),
-      data: event.name.startsWith('create') ? JSON.stringify(unflattenObject(_.get(bundle, 'inputData', {}))) : '',
+      params: event.name.startsWith('create')
+        ? {}
+        : _.get(bundle, 'inputData', {}),
+      data: event.name.startsWith('create')
+        ? JSON.stringify(unflattenObject(_.get(bundle, 'inputData', {})))
+        : ''
     },
     auth_fields: _.get(bundle, 'authData', {}),
     meta: _.get(bundle, 'meta', {}),
     zap: {
-      id: _.get(bundle, ['meta', 'zap', 'id'], 0),
+      id: _.get(bundle, ['meta', 'zap', 'id'], 0)
     },
-    url_raw: _.get(bundle, '_legacyUrl', ''),
+    url_raw: _.get(bundle, '_legacyUrl', '')
   };
 
   addAuthData(event, bundle, convertedBundle);

--- a/index.js
+++ b/index.js
@@ -77,6 +77,68 @@ const compileLegacyScriptingSource = source => {
   );
 };
 
+const promiseChain = (initialPromise, callbacks) => {
+  // Equivalent to initialPromise.then(callbacks[0]).then(callbacks[1])...
+  return callbacks.reduce((prev, cur) => prev.then(cur), initialPromise);
+};
+
+const createEventNameToMethodMapping = key => {
+  return {
+    //
+    // Auth
+    //
+    'auth.session': 'get_session_info',
+    'auth.connectionLabel': 'get_connection_label',
+    'auth.oauth2.token.pre': 'pre_oauthv2_token',
+    'auth.oauth2.token.post': 'post_oauthv2_token',
+    'auth.oauth2.refresh.pre': 'pre_oauthv2_refresh',
+
+    //
+    // Triggers
+    //
+    'trigger.poll': `${key}_poll`,
+    'trigger.pre': `${key}_pre_poll`,
+    'trigger.post': `${key}_post_poll`,
+    'trigger.hook': `${key}_catch_hook`,
+    'trigger.hook.pre': `${key}_pre_hook`,
+    'trigger.hook.post': `${key}_post_hook`,
+    'trigger.hook.subscribe.pre': 'pre_subscribe',
+    'trigger.hook.subscribe.post': 'post_subscribe',
+    'trigger.hook.unsubscribe.pre': 'pre_unsubscribe',
+    'trigger.output.pre': `${key}_pre_custom_trigger_fields`,
+    'trigger.output.post': `${key}_post_custom_trigger_fields`,
+
+    //
+    // Creates
+    //
+    'create.write': `${key}_write`,
+    'create.pre': `${key}_pre_write`,
+    'create.post': `${key}_post_write`,
+    'create.input': `${key}_custom_action_fields`,
+    'create.input.pre': `${key}_pre_custom_action_fields`,
+    'create.input.post': `${key}_post_custom_action_fields`,
+    'create.output': `${key}_custom_action_result_fields`,
+    'create.output.pre': `${key}_pre_custom_action_result_fields`,
+    'create.output.post': `${key}_post_custom_action_result_fields`,
+
+    //
+    // Searches
+    //
+    'search.search': `${key}_search`,
+    'search.pre': `${key}_pre_search`,
+    'search.post': `${key}_post_search`,
+    'search.resource': `${key}_read_resource`,
+    'search.resource.pre': `${key}_pre_read_resource`,
+    'search.resource.post': `${key}_post_read_resource`,
+    'search.input': `${key}_custom_search_fields`,
+    'search.input.pre': `${key}_pre_custom_search_fields`,
+    'search.input.post': `${key}_post_custom_search_fields`,
+    'search.output': `${key}_custom_search_result_fields`,
+    'search.output.pre': `${key}_pre_custom_search_result_fields`,
+    'search.output.post': `${key}_post_custom_search_result_fields`
+  };
+};
+
 const legacyScriptingRunner = (Zap, zobj, app) => {
   if (typeof Zap === 'string') {
     Zap = compileLegacyScriptingSource(Zap);
@@ -98,62 +160,7 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
       }
 
       const convertedBundle = bundleConverter(bundle, event);
-
-      const eventNameToMethod = {
-        //
-        // Auth
-        //
-        'auth.session': 'get_session_info',
-        'auth.connectionLabel': 'get_connection_label',
-        'auth.oauth2.token.pre': 'pre_oauthv2_token',
-        'auth.oauth2.token.post': 'post_oauthv2_token',
-        'auth.oauth2.refresh.pre': 'pre_oauthv2_refresh',
-
-        //
-        // Triggers
-        //
-        'trigger.poll': `${event.key}_poll`,
-        'trigger.pre': `${event.key}_pre_poll`,
-        'trigger.post': `${event.key}_post_poll`,
-        'trigger.hook': `${event.key}_catch_hook`,
-        'trigger.hook.pre': `${event.key}_pre_hook`,
-        'trigger.hook.post': `${event.key}_post_hook`,
-        'trigger.hook.subscribe.pre': 'pre_subscribe',
-        'trigger.hook.subscribe.post': 'post_subscribe',
-        'trigger.hook.unsubscribe.pre': 'pre_unsubscribe',
-        'trigger.output.pre': `${event.key}_pre_custom_trigger_fields`,
-        'trigger.output.post': `${event.key}_post_custom_trigger_fields`,
-
-        //
-        // Creates
-        //
-        'create.write': `${event.key}_write`,
-        'create.pre': `${event.key}_pre_write`,
-        'create.post': `${event.key}_post_write`,
-        'create.input': `${event.key}_custom_action_fields`,
-        'create.input.pre': `${event.key}_pre_custom_action_fields`,
-        'create.input.post': `${event.key}_post_custom_action_fields`,
-        'create.output': `${event.key}_custom_action_result_fields`,
-        'create.output.pre': `${event.key}_pre_custom_action_result_fields`,
-        'create.output.post': `${event.key}_post_custom_action_result_fields`,
-
-        //
-        // Searches
-        //
-        'search.search': `${event.key}_search`,
-        'search.pre': `${event.key}_pre_search`,
-        'search.post': `${event.key}_post_search`,
-        'search.resource': `${event.key}_read_resource`,
-        'search.resource.pre': `${event.key}_pre_read_resource`,
-        'search.resource.post': `${event.key}_post_read_resource`,
-        'search.input': `${event.key}_custom_search_fields`,
-        'search.input.pre': `${event.key}_pre_custom_search_fields`,
-        'search.input.post': `${event.key}_post_custom_search_fields`,
-        'search.output': `${event.key}_custom_search_result_fields`,
-        'search.output.pre': `${event.key}_pre_custom_search_result_fields`,
-        'search.output.post': `${event.key}_post_custom_search_result_fields`
-      };
-
+      const eventNameToMethod = createEventNameToMethodMapping(event.key);
       const methodName = eventNameToMethod[event.name];
 
       if (methodName && _.isFunction(Zap[methodName])) {
@@ -184,18 +191,66 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
       return undefined;
     });
 
-  const runOAuth2GetAccessToken = bundle => {
-    let promise = null;
+  // Simulates how WB backend runs JS scripting methods
+  const runEventCombo = (
+    bundle,
+    key,
+    preEventName,
+    postEventName,
+    fullEventName
+  ) => {
+    let promise;
     const funcs = [];
 
-    bundle._legacyUrl = _.get(
+    const eventNameToMethod = createEventNameToMethodMapping(key);
+
+    const preMethodName = preEventName ? eventNameToMethod[preEventName] : null;
+    const postMethodName = postEventName
+      ? eventNameToMethod[postEventName]
+      : null;
+    const fullMethodName = fullEventName
+      ? eventNameToMethod[fullEventName]
+      : null;
+
+    const fullMethod = fullMethodName ? Zap[fullMethodName] : null;
+    if (fullMethod) {
+      // Running "full" scripting method like KEY_poll
+      promise = runEvent({ key, name: fullEventName }, zobj, bundle);
+    } else {
+      const preMethod = preMethodName ? Zap[preMethodName] : null;
+      if (preMethod) {
+        promise = runEvent({ key, name: preEventName }, zobj, bundle);
+      } else {
+        promise = Promise.resolve(bundle.request);
+      }
+
+      funcs.push(request => zobj.request(request));
+
+      const postMethod = postMethodName ? Zap[postMethodName] : null;
+      if (postMethod) {
+        funcs.push(response => {
+          response.throwForStatus();
+          return runEvent({ key, name: postEventName, response }, zobj, bundle);
+        });
+      } else {
+        funcs.push(response => {
+          response.throwForStatus();
+          return zobj.JSON.parse(response.content);
+        });
+      }
+    }
+
+    return promiseChain(promise, funcs);
+  };
+
+  const runOAuth2GetAccessToken = bundle => {
+    const url = _.get(
       app,
       'authentication.oauth2Config.legacyProperties.accessTokenUrl'
     );
-    bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
     bundle.request = {
       method: 'POST',
-      url: bundle._legacyUrl,
+      url,
       body: {
         code: bundle.inputData.code,
         client_id: process.env.CLIENT_ID,
@@ -208,47 +263,22 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
       }
     };
 
-    const preMethod = Zap.pre_oauthv2_token;
-    if (preMethod) {
-      promise = runEvent({ name: 'auth.oauth2.token.pre' }, zobj, bundle);
-    } else {
-      promise = Promise.resolve(bundle.request);
-    }
-
-    funcs.push(request => {
-      return zobj.request(request);
-    });
-
-    const postMethod = Zap.post_oauthv2_token;
-    if (postMethod) {
-      funcs.push(response => {
-        response.throwForStatus();
-        return runEvent(
-          { name: 'auth.oauth2.token.post', response },
-          zobj,
-          bundle
-        );
-      });
-    } else {
-      funcs.push(response => {
-        response.throwForStatus();
-        return zobj.JSON.parse(response.content);
-      });
-    }
-
-    // Equivalent to promise.then(funcs[0]).then(funcs[1])...
-    return funcs.reduce((prev, cur) => prev.then(cur), promise);
+    return runEventCombo(
+      bundle,
+      '',
+      'auth.oauth2.token.pre',
+      'auth.oauth2.token.post'
+    );
   };
 
   const runOAuth2RefreshAccessToken = bundle => {
-    bundle._legacyUrl = _.get(
+    const url = _.get(
       app,
       'authentication.oauth2Config.legacyProperties.refreshTokenUrl'
     );
-    bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
     bundle.request = {
       method: 'POST',
-      url: bundle._legacyUrl,
+      url,
       body: {
         client_id: process.env.CLIENT_ID,
         client_secret: process.env.CLIENT_SECRET,
@@ -260,72 +290,24 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
       }
     };
 
-    let promise;
-    const preMethod = Zap.pre_oauthv2_token;
-    if (preMethod) {
-      promise = runEvent({ name: 'auth.oauth2.refresh.pre' }, zobj, bundle);
-    } else {
-      promise = Promise.resolve(bundle.request);
-    }
-
-    return promise.then(request => zobj.request(request)).then(response => {
-      response.throwForStatus();
-      return zobj.JSON.parse(response.content);
-    });
+    return runEventCombo(bundle, '', 'auth.oauth2.refresh.pre');
   };
 
   const runTrigger = (bundle, key) => {
-    let promise = null;
-    const funcs = [];
-
-    bundle._legacyUrl = _.get(
-      app,
-      `triggers.${key}.operation.legacyProperties.url`
+    const url = _.get(app, `triggers.${key}.operation.legacyProperties.url`);
+    bundle.request = { url };
+    return runEventCombo(
+      bundle,
+      key,
+      'trigger.pre',
+      'trigger.post',
+      'trigger.poll'
     );
-    bundle._legacyUrl = replaceVars(bundle._legacyUrl, bundle);
-
-    const fullMethod = Zap[`${key}_poll`];
-    if (fullMethod) {
-      promise = runEvent({ key, name: 'trigger.poll' }, zobj, bundle);
-    } else {
-      const preMethod = Zap[`${key}_pre_poll`];
-      if (preMethod) {
-        promise = runEvent({ key, name: 'trigger.pre' }, zobj, bundle);
-      } else {
-        promise = Promise.resolve({
-          url: bundle._legacyUrl
-        });
-      }
-
-      funcs.push(request => {
-        return zobj.request(request);
-      });
-
-      const postMethod = Zap[`${key}_post_poll`];
-      if (postMethod) {
-        funcs.push(response => {
-          response.throwForStatus();
-          return runEvent(
-            { key, name: 'trigger.post', response },
-            zobj,
-            bundle
-          );
-        });
-      } else {
-        funcs.push(response => {
-          response.throwForStatus();
-          return zobj.JSON.parse(response.content);
-        });
-      }
-    }
-
-    // Equivalent to promise.then(funcs[0]).then(funcs[1])...
-    return funcs.reduce((prev, cur) => prev.then(cur), promise);
   };
 
-  // Simulates how backend run legacy scripting. core exposes this as
-  // z.legacyScripting.run() method that we can run legacy scripting easily
-  // like z.legacyScripting.run(bundle, 'trigger', 'KEY') in CLI.
+  // core exposes this function as z.legacyScripting.run() method that we can
+  // run legacy scripting easily like z.legacyScripting.run(bundle, 'trigger', 'KEY')
+  // in CLI to simulate how WB backend runs legacy scripting.
   const run = (bundle, typeOf, key) => {
     switch (typeOf) {
       case 'auth.session':

--- a/package-lock.json
+++ b/package-lock.json
@@ -540,9 +540,9 @@
       }
     },
     "deasync": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.10.tgz",
-      "integrity": "sha1-TkpoNvvgR3vV+Qgwi9KpZVfV1/4=",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.12.tgz",
+      "integrity": "sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==",
       "requires": {
         "bindings": "~1.2.1",
         "nan": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "ci-test": "npm test && ./ci-test.js"
   },
   "engines": {
-    "node": ">=6.10.2",
-    "npm": ">=3.0.0"
+    "node": ">=8.10.0",
+    "npm": ">=5.6.0"
   },
   "dependencies": {
     "async": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "UNLICENSED",
   "main": "index.js",
   "files": [
-      "/*.js"
+    "/*.js"
   ],
   "scripts": {
     "lint": "node_modules/.bin/eslint .",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "async": "2.6.1",
-    "deasync": "0.1.10",
+    "deasync": "0.1.12",
     "lodash": "4.17.10",
     "moment-timezone": "0.5.17",
     "node-jquery-param": "0.0.2",

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -24,6 +24,23 @@ const legacyScriptingSource = `
         };
       },
 
+      pre_oauthv2_token: function(bundle) {
+        bundle.request.url += 'token';
+        return bundle.request;
+      },
+
+      post_oauthv2_token: function(bundle) {
+        var data = z.JSON.parse(bundle.response.content);
+        data.something_custom += '!!';
+        data.name = 'Jane Doe';
+        return data;
+      },
+
+      pre_oauthv2_refresh: function(bundle) {
+        bundle.request.url += 'token';
+        return bundle.request;
+      },
+
       get_connection_label: function(bundle) {
         return 'Hi ' + bundle.test_result.name;
       },

--- a/test/example-app/oauth2.js
+++ b/test/example-app/oauth2.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const testAuthSource = `
+  const responsePromise = z.request({
+    url: 'https://auth-json-server.zapier.ninja/me'
+  });
+  return responsePromise.then(response => {
+    if (response.status !== 200) {
+      throw new Error('Auth failed');
+    }
+    return z.JSON.parse(response.content);
+  });
+`;
+
+const getAccessTokenSource = `
+  return z.legacyScripting.run(bundle, 'auth.oauth2.token');
+`;
+
+const refreshAccessTokenSource = `
+  return z.legacyScripting.run(bundle, 'auth.oauth2.refresh');
+`;
+
+const maybeIncludeAuthSource = `
+  if (bundle.authData.access_token) {
+    request.headers.Authorization = \`Bearer \${bundle.authData.access_token}\`;
+  }
+  return request;
+`;
+
+module.exports = {
+  authentication: {
+    type: 'oauth2',
+    test: { source: testAuthSource },
+    fields: [
+      // No need to define access_token and refresh_token here, they will be
+      // added automatically by the backend
+      {
+        key: 'something_custom',
+        type: 'string',
+        required: true,
+        computed: true
+      }
+    ],
+    oauth2Config: {
+      legacyProperties: {
+        // Incomplete URLs on purpose to test pre_oauthv2_token
+        accessTokenUrl: 'https://auth-json-server.zapier.ninja/oauth/access-',
+        refreshTokenUrl: 'https://auth-json-server.zapier.ninja/oauth/refresh-'
+      },
+      authorizeUrl: {
+        method: 'GET',
+        url: 'https://auth-json-server.zapier.ninja/oauth/authorize',
+        params: {
+          client_id: '{{process.env.CLIENT_ID}}',
+          state: '{{bundle.inputData.state}}',
+          redirect_uri: '{{bundle.inputData.redirect_uri}}',
+          response_type: 'code'
+        }
+      },
+      getAccessToken: {
+        source: getAccessTokenSource
+      },
+      refreshAccessToken: {
+        source: refreshAccessTokenSource
+      },
+      autoRefresh: true
+    }
+  },
+  beforeRequest: [{ source: maybeIncludeAuthSource, args: ['request', 'z', 'bundle'] }]
+
+  // We don't need afterResponse to refresh auth as core appends one
+  // automatically when autoRefresh is true
+};

--- a/test/example-app/session-auth.js
+++ b/test/example-app/session-auth.js
@@ -57,6 +57,10 @@ module.exports = {
     },
     connectionLabel: { source: getConnectionLabelSource }
   },
-  beforeRequest: [{ source: maybeIncludeAuthSource }],
-  afterResponse: [{ source: maybeRefreshAuthSource }]
+  beforeRequest: [
+    { source: maybeIncludeAuthSource, args: ['request', 'z', 'bundle'] }
+  ],
+  afterResponse: [
+    { source: maybeRefreshAuthSource, args: ['response', 'z', 'bundle'] }
+  ]
 };

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -4,12 +4,14 @@ const _ = require('lodash');
 const should = require('should');
 
 const appDefinition = require('./example-app');
+const oauth2Config = require('./example-app/oauth2');
 const sessionAuthConfig = require('./example-app/session-auth');
 const createApp = require('zapier-platform-core/src/create-app');
 const createInput = require('zapier-platform-core/src/tools/create-input');
+const schemaTools = require('zapier-platform-core/src/tools/schema');
 
 const withAuth = (appDef, authConfig) => {
-  return _.extend(_.cloneDeep(appDef), authConfig);
+  return _.extend(_.cloneDeep(appDef), _.cloneDeep(authConfig));
 };
 
 // TODO: This is currently failing. Remove .skip once core 6.2.0 is released.
@@ -19,21 +21,24 @@ describe.skip('Integration Test', () => {
     return Promise.resolve({});
   };
 
-  const createTestInput = method => {
+  const createTestInput = (compiledApp, method) => {
     const event = {
       bundle: {},
       method
     };
-
-    return createInput(appDefinition, event, testLogger);
+    return createInput(compiledApp, event, testLogger);
   };
 
-  describe('auth', () => {
+  describe('session auth', () => {
     const appDefWithAuth = withAuth(appDefinition, sessionAuthConfig);
+    const compiledApp = schemaTools.prepareApp(appDefWithAuth);
     const app = createApp(appDefWithAuth);
 
     it('get_session_info', () => {
-      const input = createTestInput('authentication.sessionConfig.perform');
+      const input = createTestInput(
+        compiledApp,
+        'authentication.sessionConfig.perform'
+      );
       input.bundle.authData = {
         username: 'user',
         password: 'secret'
@@ -45,7 +50,10 @@ describe.skip('Integration Test', () => {
     });
 
     it('get_connection_label', () => {
-      const input = createTestInput('authentication.connectionLabel');
+      const input = createTestInput(
+        compiledApp,
+        'authentication.connectionLabel'
+      );
       input.bundle.inputData = {
         name: 'Mark'
       };
@@ -55,11 +63,117 @@ describe.skip('Integration Test', () => {
     });
   });
 
+  describe('oauth2', () => {
+    let origEnv;
+
+    beforeEach(() => {
+      origEnv = process.env;
+      process.env = {
+        CLIENT_ID: '1234',
+        CLIENT_SECRET: 'asdf'
+      };
+    });
+
+    afterEach(() => {
+      process.env = origEnv;
+    });
+
+    it('pre_oauthv2_token', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'post_oauthv2_token',
+        'dont_care'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.getAccessToken'
+      );
+      input.bundle.inputData = {
+        redirect_uri: 'https://example.com',
+        code: 'one_time_code'
+      };
+      return app(input).then(output => {
+        should.equal(output.results.access_token, 'a_token');
+        should.equal(output.results.something_custom, 'alright!');
+        should.not.exist(output.results.name);
+      });
+    });
+
+    it('post_oauthv2_token', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'pre_oauthv2_token',
+        'dont_care'
+      );
+      appDefWithAuth.authentication.oauth2Config.legacyProperties.accessTokenUrl +=
+        'token';
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.getAccessToken'
+      );
+      input.bundle.inputData = {
+        redirect_uri: 'https://example.com',
+        code: 'one_time_code'
+      };
+      return app(input).then(output => {
+        should.equal(output.results.access_token, 'a_token');
+        should.equal(output.results.something_custom, 'alright!!!');
+        should.equal(output.results.name, 'Jane Doe');
+      });
+    });
+
+    it('pre_oauthv2_token & post_oauthv2_token', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.getAccessToken'
+      );
+      input.bundle.inputData = {
+        redirect_uri: 'https://example.com',
+        code: 'one_time_code'
+      };
+      return app(input).then(output => {
+        should.equal(output.results.access_token, 'a_token');
+        should.equal(output.results.something_custom, 'alright!!!');
+        should.equal(output.results.name, 'Jane Doe');
+      });
+    });
+
+    it('pre_oauthv2_refresh', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.refreshAccessToken'
+      );
+      input.bundle.authData = {
+        refresh_token: 'a_refresh_token'
+      };
+      return app(input).then(output => {
+        should.equal(output.results.access_token, 'a_new_token');
+      });
+    });
+  });
+
   describe('trigger', () => {
     const app = createApp(appDefinition);
 
     it('KEY_poll', () => {
-      const input = createTestInput('triggers.contact_full.operation.perform');
+      const input = createTestInput(
+        appDefinition,
+        'triggers.contact_full.operation.perform'
+      );
       return app(input).then(output => {
         output.results.length.should.greaterThan(1);
 
@@ -69,7 +183,10 @@ describe.skip('Integration Test', () => {
     });
 
     it('KEY_pre_poll', () => {
-      const input = createTestInput('triggers.contact_pre.operation.perform');
+      const input = createTestInput(
+        appDefinition,
+        'triggers.contact_pre.operation.perform'
+      );
       return app(input).then(output => {
         output.results.length.should.equal(1);
 
@@ -79,7 +196,10 @@ describe.skip('Integration Test', () => {
     });
 
     it('KEY_post_poll', () => {
-      const input = createTestInput('triggers.contact_post.operation.perform');
+      const input = createTestInput(
+        appDefinition,
+        'triggers.contact_post.operation.perform'
+      );
       return app(input).then(output => {
         output.results.length.should.greaterThan(1);
 
@@ -90,6 +210,7 @@ describe.skip('Integration Test', () => {
 
     it('KEY_pre_poll & KEY_post_poll', () => {
       const input = createTestInput(
+        appDefinition,
         'triggers.contact_pre_post.operation.perform'
       );
       return app(input).then(output => {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -14,7 +14,7 @@ const withAuth = (appDef, authConfig) => {
   return _.extend(_.cloneDeep(appDef), _.cloneDeep(authConfig));
 };
 
-// TODO: This is currently failing. Remove .skip once core 6.2.0 is released.
+// TODO: This is currently failing. Remove .skip once core 7.0.0 is released.
 describe.skip('Integration Test', () => {
   const testLogger = (/* message, data */) => {
     // console.log(message, data);


### PR DESCRIPTION
Allows to run OAuth2 scripting with `z.legacyScripting.run(bundle, 'auth.oauth2.token')` and `z.legacyScripting.run(bundle, 'auth.oauth2.refresh')`.

Also refactors and bumps Node version to 8.10.0.