### PR TITLE
Apply beforeRequest middleware to bundle.request before calling scripting methods

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -62,17 +62,6 @@ const addAuthData = (event, bundle, convertedBundle) => {
     convertedBundle.request.auth = [username, password];
   }
 
-  const headers = _.get(bundle, 'request.headers', {});
-  _.extend(convertedBundle.request.headers, headers);
-
-  const params = _.get(bundle, 'request.params', {});
-  _.extend(convertedBundle.request.params, params);
-
-  const body = _.get(bundle, 'request.body');
-  if (body) {
-    convertedBundle.request.data = body;
-  }
-
   // OAuth2 specific
   if (event.name.startsWith('auth.oauth2')) {
     convertedBundle.oauth_data = {
@@ -130,6 +119,22 @@ const addHookData = (event, bundle, convertedBundle) => {
   }
 };
 
+const addRequest = (event, bundle, convertedBundle) => {
+  const headers = _.get(bundle, 'request.headers', {});
+  _.extend(convertedBundle.request.headers, headers);
+
+  const params = _.get(bundle, 'request.params', {});
+  _.extend(convertedBundle.request.params, params);
+
+  let body = _.get(bundle, 'request.body');
+  if (body) {
+    if (typeof body !== 'string') {
+      body = JSON.stringify(body);
+    }
+    convertedBundle.request.data = body;
+  }
+};
+
 const addResponse = (event, bundle, convertedBundle) => {
   if (event.name.endsWith('.post') || event.name.endsWith('.output')) {
     convertedBundle.response = event.response;
@@ -172,11 +177,9 @@ const bundleConverter = (bundle, event) => {
   };
 
   addAuthData(event, bundle, convertedBundle);
-
   addInputData(event, bundle, convertedBundle);
-
   addHookData(event, bundle, convertedBundle);
-
+  addRequest(event, bundle, convertedBundle);
   addResponse(event, bundle, convertedBundle);
 
   return convertedBundle;

--- a/test/example-app/api-key-auth.js
+++ b/test/example-app/api-key-auth.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const testAuthSource = `
+  const responsePromise = z.request({
+    url: 'https://auth-json-server.zapier.ninja/me'
+  });
+  return responsePromise.then(response => {
+    if (response.status !== 200) {
+      throw new Error('Auth failed');
+    }
+    return z.JSON.parse(response.content);
+  });
+`;
+
+const maybeIncludeAuthSource = `
+  if (bundle.authData.api_key) {
+    request.headers['X-API-Key'] = bundle.authData.api_key;
+  }
+  return request;
+`;
+
+module.exports = {
+  authentication: {
+    type: 'custom',
+    test: { source: testAuthSource },
+    fields: [
+      {
+        key: 'api_key',
+        label: 'API Key',
+        type: 'string',
+        required: true
+      }
+    ]
+  },
+  beforeRequest: [
+    { source: maybeIncludeAuthSource, args: ['request', 'z', 'bundle'] }
+  ]
+};

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -46,20 +46,16 @@ const legacyScriptingSource = `
       },
 
       contact_full_poll: function(bundle) {
-        var response = z.request({
-          url: 'https://auth-json-server.zapier.ninja/users',
-          params: { api_key: 'secret' }
-        });
+        bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
+        var response = z.request(bundle.request);
         var contacts = z.JSON.parse(response.content);
         contacts[0].name = 'Patched by KEY_poll!';
         return contacts;
       },
 
       contact_pre_pre_poll: function(bundle) {
-        bundle.request = {
-          url: 'https://auth-json-server.zapier.ninja/users',
-          params: { api_key: 'secret', id: 3 }
-        };
+        bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
+        bundle.request.params.id = 3;
         return bundle.request;
       },
 
@@ -70,10 +66,8 @@ const legacyScriptingSource = `
       },
 
       contact_pre_post_pre_poll: function(bundle) {
-        bundle.request = {
-          url: 'https://auth-json-server.zapier.ninja/users',
-          params: { api_key: 'secret', id: 4 }
-        };
+        bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
+        bundle.request.params.id = 4;
         return bundle.request;
       },
 
@@ -135,7 +129,7 @@ const ContactTrigger_post = {
   },
   operation: {
     legacyProperties: {
-      url: 'https://auth-json-server.zapier.ninja/users?api_key=secret'
+      url: 'https://auth-json-server.zapier.ninja/users'
     },
     perform: {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'contact_post');"

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const should = require('should');
 
+const apiKeyAuth = require('./example-app/api-key-auth');
 const appDefinition = require('./example-app');
 const oauth2Config = require('./example-app/oauth2');
 const sessionAuthConfig = require('./example-app/session-auth');
@@ -166,13 +167,16 @@ describe('Integration Test', () => {
   });
 
   describe('trigger', () => {
-    const app = createApp(appDefinition);
+    const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+    const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+    const app = createApp(appDefWithAuth);
 
     it('KEY_poll', () => {
       const input = createTestInput(
-        appDefinition,
+        compiledApp,
         'triggers.contact_full.operation.perform'
       );
+      input.bundle.authData = { api_key: 'secret' };
       return app(input).then(output => {
         output.results.length.should.greaterThan(1);
 
@@ -183,9 +187,10 @@ describe('Integration Test', () => {
 
     it('KEY_pre_poll', () => {
       const input = createTestInput(
-        appDefinition,
+        compiledApp,
         'triggers.contact_pre.operation.perform'
       );
+      input.bundle.authData = { api_key: 'secret' };
       return app(input).then(output => {
         output.results.length.should.equal(1);
 
@@ -196,9 +201,10 @@ describe('Integration Test', () => {
 
     it('KEY_post_poll', () => {
       const input = createTestInput(
-        appDefinition,
+        compiledApp,
         'triggers.contact_post.operation.perform'
       );
+      input.bundle.authData = { api_key: 'secret' };
       return app(input).then(output => {
         output.results.length.should.greaterThan(1);
 
@@ -209,9 +215,10 @@ describe('Integration Test', () => {
 
     it('KEY_pre_poll & KEY_post_poll', () => {
       const input = createTestInput(
-        appDefinition,
+        compiledApp,
         'triggers.contact_pre_post.operation.perform'
       );
+      input.bundle.authData = { api_key: 'secret' };
       return app(input).then(output => {
         output.results.length.should.equal(1);
 
@@ -278,13 +285,13 @@ describe('Integration Test', () => {
         'triggers.contact_hook_scripting.operation.perform'
       );
       input.bundle.cleanedRequest = [
-        {id: 11, name: 'Cate'},
-        {id: 22, name: 'Dave'}
+        { id: 11, name: 'Cate' },
+        { id: 22, name: 'Dave' }
       ];
       return app(input).then(output => {
         output.results.should.deepEqual([
-          {id: 11, name: 'Cate', luckyNumber: 110},
-          {id: 22, name: 'Dave', luckyNumber: 220}
+          { id: 11, name: 'Cate', luckyNumber: 110 },
+          { id: 22, name: 'Dave', luckyNumber: 220 }
         ]);
       });
     });


### PR DESCRIPTION
In CLI, `z.request` invokes `beforeRequest` middleware under the hood to do authentication. In WB scripting, however, `z.request` doesn't have any of that magic. Instead, WB backend sets the auth data into `bundle.request` and passes it to a scripting method.

This PR simulates this behavior by applying `beforeRequest` middleware to `bundle.request` before it gets passed to a scripting method. The trigger tests are updated to reflect the change.