### PR TITLE
KEY_(pre|post)_custom_trigger_fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -461,6 +461,20 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
     );
   };
 
+  const runTriggerOutputFields = (bundle, key) => {
+    const url = _.get(app, `triggers.${key}.operation.legacyProperties.outputFieldsUrl`);
+    bundle.request.url = url;
+
+    return runEventCombo(
+      bundle,
+      key,
+      'trigger.output.pre',
+      'trigger.output.post',
+      undefined,
+      { ensureArray: 'wrap' }
+    );
+  };
+
   // core exposes this function as z.legacyScripting.run() method that we can
   // run legacy scripting easily like z.legacyScripting.run(bundle, 'trigger', 'KEY')
   // in CLI to simulate how WB backend runs legacy scripting.
@@ -495,9 +509,10 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
           return runHookSubscribe(bundle, key);
         case 'trigger.hook.unsubscribe':
           return runHookUnsubscribe(bundle, key);
+        case 'trigger.output':
+          return runTriggerOutputFields(bundle, key);
 
         // TODO: Add support for these:
-        // trigger.output
         // create
         // create.input
         // create.output

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -45,12 +45,31 @@ const legacyScriptingSource = `
         return 'Hi ' + bundle.test_result.name;
       },
 
+      /*
+       * Polling Trigger
+       */
+
       contact_full_poll: function(bundle) {
         bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
         var response = z.request(bundle.request);
         var contacts = z.JSON.parse(response.content);
         contacts[0].name = 'Patched by KEY_poll!';
         return contacts;
+      },
+
+      contact_full_pre_custom_trigger_fields: function(bundle) {
+        bundle.request.url += 's';
+        return bundle.request;
+      },
+
+      contact_full_post_custom_trigger_fields: function(bundle) {
+        var fields = z.JSON.parse(bundle.response.content);
+        fields.push({
+          key: 'spin',
+          label: 'Spin',
+          type: 'string'
+        });
+        return fields;
       },
 
       contact_pre_pre_poll: function(bundle) {
@@ -76,6 +95,10 @@ const legacyScriptingSource = `
         contacts[0].name = 'Patched by KEY_pre_poll & KEY_post_poll!';
         return contacts;
       },
+
+      /*
+       * Hook Trigger
+       */
 
       // To be replaced to 'contact_hook_scripting_catch_hook' at runtime
       contact_hook_scripting_catch_hook_returning_object: function(bundle) {
@@ -153,6 +176,27 @@ const ContactTrigger_full = {
   operation: {
     perform: {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'contact_full');"
+    },
+    outputFields: [
+      {
+        key: 'id',
+        label: 'ID',
+        type: 'integer'
+      },
+      {
+        key: 'name',
+        label: 'Name',
+        type: 'string'
+      },
+      {
+        source:
+          "return z.legacyScripting.run(bundle, 'trigger.output', 'contact_full');"
+      }
+    ],
+    legacyProperties: {
+      // Misses an 's' at the end on purpose for KEY_pre_custom_trigger_fields
+      // to fix
+      outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field'
     }
   }
 };

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -243,6 +243,79 @@ describe('Integration Test', () => {
         should.equal(user.username, 'Bret');
       });
     });
+
+    it('KEY_pre_custom_trigger_fields', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+        'contact_full_post_custom_trigger_fields',
+        'contact_full_post_custom_trigger_fields_disabled'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.contact_full.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 5);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'name');
+        should.equal(fields[2].key, 'id');
+        should.equal(fields[3].key, 'color');
+        should.equal(fields[4].key, 'age');
+      });
+    });
+
+    it('KEY_post_custom_trigger_fields', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.triggers.contact_full.operation.legacyProperties.outputFieldsUrl +=
+        's';
+      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+        'contact_full_pre_custom_trigger_fields',
+        'contact_full_pre_custom_trigger_fields_disabled'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.contact_full.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 6);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'name');
+        should.equal(fields[2].key, 'id');
+        should.equal(fields[3].key, 'color');
+        should.equal(fields[4].key, 'age');
+        should.equal(fields[5].key, 'spin');
+      });
+    });
+
+    it('KEY_pre_custom_trigger_fields & KEY_post_custom_trigger_fields', () => {
+      const input = createTestInput(
+        compiledApp,
+        'triggers.contact_full.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 6);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'name');
+        should.equal(fields[2].key, 'id');
+        should.equal(fields[3].key, 'color');
+        should.equal(fields[4].key, 'age');
+        should.equal(fields[5].key, 'spin');
+      });
+    });
   });
 
   describe('hook trigger', () => {


### PR DESCRIPTION
Adds support for `KEY_pre_custom_trigger_fields` and `KEY_post_custom_trigger_fields`, which can be invoked by `z.legacyScripting.run(bundle, 'trigger.output', 'KEY')` in a CLI app definition.

Note that this PR uses https://auth-json-server.zapier.ninja/output-fields?api_key=secret to test custom output fields.