### PR TITLE
Search custom fields scripting

### DIFF
--- a/index.js
+++ b/index.js
@@ -578,6 +578,22 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
     return runCustomFields(bundle, key, 'create.output', url);
   };
 
+  const runSearchInputFields = (bundle, key) => {
+    const url = _.get(
+      app,
+      `searches.${key}.operation.legacyProperties.inputFieldsUrl`
+    );
+    return runCustomFields(bundle, key, 'search.input', url);
+  };
+
+  const runSearchOutputFields = (bundle, key) => {
+    const url = _.get(
+      app,
+      `searches.${key}.operation.legacyProperties.outputFieldsUrl`
+    );
+    return runCustomFields(bundle, key, 'search.output', url);
+  };
+
   // core exposes this function as z.legacyScripting.run() method that we can
   // run legacy scripting easily like z.legacyScripting.run(bundle, 'trigger', 'KEY')
   // in CLI to simulate how WB backend runs legacy scripting.
@@ -621,12 +637,14 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
           return runCreateInputFields(bundle, key);
         case 'create.output':
           return runCreateOutputFields(bundle, key);
+        case 'search.input':
+          return runSearchInputFields(bundle, key);
+        case 'search.output':
+          return runSearchOutputFields(bundle, key);
 
         // TODO: Add support for these:
         // search
         // search.resource
-        // search.input
-        // search.output
       }
       throw new Error(`unrecognizable typeOf '${typeOf}'`);
     });

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -273,6 +273,77 @@ const legacyScriptingSource = `
             callback(err, fields);
           }
         });
+      },
+
+      /*
+       * Search
+       */
+
+      // To be replaced with 'movie_pre_custom_search_fields' at runtime
+      movie_pre_custom_search_fields_disabled: function(bundle) {
+        bundle.request.url += 's';
+        return bundle.request;
+      },
+
+      // To be replaced with 'movie_post_custom_search_fields' at runtime
+      movie_post_custom_search_fields_disabled: function(bundle) {
+        var fields = z.JSON.parse(bundle.response.content);
+        fields.push({
+          key: 'year',
+          label: 'Year',
+          type: 'int'
+        });
+        return fields;
+      },
+
+      // To be replaced with 'movie_custom_search_fields' at runtime
+      movie_custom_search_fields_disabled: function(bundle) {
+        // bundle.request.url should be an empty string to start with
+        bundle.request.url += 'https://auth-json-server.zapier.ninja/input-fields';
+        var response = z.request(bundle.request);
+        var fields = z.JSON.parse(response.content);
+        fields.push({
+          key: 'year',
+          label: 'Year',
+          type: 'int'
+        });
+        return fields;
+      },
+
+      // To be replaced with 'movie_pre_custom_search_result_fields' at runtime
+      movie_pre_custom_search_result_fields_disabled: function(bundle) {
+        bundle.request.url += 's';
+        return bundle.request;
+      },
+
+      // To be replaced with 'movie_post_custom_search_result_fields' at runtime
+      movie_post_custom_search_result_fields_disabled: function(bundle) {
+        var fields = z.JSON.parse(bundle.response.content);
+        fields.push({
+          key: 'tagline',
+          label: 'Tagline',
+          type: 'unicode'
+        });
+        return fields;
+      },
+
+      // To be replaced with 'movie_custom_search_result_fields' at runtime
+      movie_custom_search_result_fields_disabled: function(bundle, callback) {
+        // bundle.request.url should be an empty string to start with
+        bundle.request.url += 'https://auth-json-server.zapier.ninja/output-fields';
+        z.request(bundle.request, function(err, response) {
+          if (err) {
+            callback(err, response);
+          } else {
+            var fields = z.JSON.parse(response.content);
+            fields.push({
+              key: 'tagline',
+              label: 'Tagline',
+              type: 'unicode'
+            });
+            callback(err, fields);
+          }
+        });
       }
     };
 `;
@@ -445,6 +516,40 @@ const MovieCreate = {
   }
 };
 
+const MovieSearch = {
+  key: 'movie',
+  noun: 'Movie',
+  display: {
+    label: 'Find a Movie'
+  },
+  operation: {
+    perform: {
+      source: "return z.legacyScripting.run(bundle, 'search', 'movie');"
+    },
+    inputFields: [
+      { key: 'title', label: 'Title', type: 'string' },
+      {
+        source: "return z.legacyScripting.run(bundle, 'search.input', 'movie');"
+      }
+    ],
+    outputFields: [
+      { key: 'id', label: 'ID', type: 'integer' },
+      { key: 'title', label: 'Title', type: 'string' },
+      { key: 'genre', label: 'Genre', type: 'string' },
+      {
+        source:
+          "return z.legacyScripting.run(bundle, 'search.output', 'movie');"
+      }
+    ],
+    legacyProperties: {
+      // The URLs miss an 's' at the end on purpose for scripting to fix it
+      url: 'https://auth-json-server.zapier.ninja/movie',
+      inputFieldsUrl: 'https://auth-json-server.zapier.ninja/input-field',
+      outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field'
+    }
+  }
+};
+
 const App = {
   title: 'Example App',
   triggers: {
@@ -458,6 +563,9 @@ const App = {
   },
   creates: {
     [MovieCreate.key]: MovieCreate
+  },
+  searches: {
+    [MovieSearch.key]: MovieSearch
   },
   legacyProperties: {
     subscribeUrl: 'http://zapier-httpbin.herokuapp.com/post',

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -962,7 +962,6 @@ describe('Integration Test', () => {
       });
     });
 
-
     it('KEY_pre_custom_action_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
@@ -1067,6 +1066,278 @@ describe('Integration Test', () => {
       const input = createTestInput(
         compiledApp,
         'creates.movie.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 7);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'title');
+        should.equal(fields[2].key, 'genre');
+        should.equal(fields[3].key, 'id');
+        should.equal(fields[4].key, 'color');
+        should.equal(fields[5].key, 'age');
+        should.equal(fields[6].key, 'tagline');
+        should.equal(fields[6].type, 'string');
+      });
+    });
+  });
+
+  describe('search', () => {
+    it('scriptingless input fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.searches.movie.operation.legacyProperties.inputFieldsUrl +=
+        's';
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.inputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 2);
+        should.equal(fields[0].key, 'title');
+        should.equal(fields[1].key, 'luckyNumber');
+      });
+    });
+
+    it('KEY_pre_custom_search_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_pre_custom_search_fields_disabled',
+        'movie_pre_custom_search_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.inputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 2);
+        should.equal(fields[0].key, 'title');
+        should.equal(fields[1].key, 'luckyNumber');
+      });
+    });
+
+    it('KEY_post_custom_search_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.searches.movie.operation.legacyProperties.inputFieldsUrl +=
+        's';
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_post_custom_search_fields_disabled',
+        'movie_post_custom_search_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.inputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 3);
+        should.equal(fields[0].key, 'title');
+        should.equal(fields[1].key, 'luckyNumber');
+        should.equal(fields[2].key, 'year');
+        should.equal(fields[2].type, 'integer');
+      });
+    });
+
+    it('KEY_pre_custom_search_fields & KEY_post_custom_search_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_pre_custom_search_fields_disabled',
+        'movie_pre_custom_search_fields'
+      );
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_post_custom_search_fields_disabled',
+        'movie_post_custom_search_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.inputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 3);
+        should.equal(fields[0].key, 'title');
+        should.equal(fields[1].key, 'luckyNumber');
+        should.equal(fields[2].key, 'year');
+        should.equal(fields[2].type, 'integer');
+      });
+    });
+
+    it('KEY_custom_search_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_custom_search_fields_disabled',
+        'movie_custom_search_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.inputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 3);
+        should.equal(fields[0].key, 'title');
+        should.equal(fields[1].key, 'luckyNumber');
+        should.equal(fields[2].key, 'year');
+        should.equal(fields[2].type, 'integer');
+      });
+    });
+
+    it('scriptingless output fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.searches.movie.operation.legacyProperties.outputFieldsUrl +=
+        's';
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 6);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'title');
+        should.equal(fields[2].key, 'genre');
+        should.equal(fields[3].key, 'id');
+        should.equal(fields[4].key, 'color');
+        should.equal(fields[5].key, 'age');
+      });
+    });
+
+    it('KEY_pre_custom_search_result_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_pre_custom_search_result_fields_disabled',
+        'movie_pre_custom_search_result_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 6);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'title');
+        should.equal(fields[2].key, 'genre');
+        should.equal(fields[3].key, 'id');
+        should.equal(fields[4].key, 'color');
+        should.equal(fields[5].key, 'age');
+      });
+    });
+
+    it('KEY_post_custom_search_result_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.searches.movie.operation.legacyProperties.outputFieldsUrl +=
+        's';
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_post_custom_search_result_fields_disabled',
+        'movie_post_custom_search_result_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 7);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'title');
+        should.equal(fields[2].key, 'genre');
+        should.equal(fields[3].key, 'id');
+        should.equal(fields[4].key, 'color');
+        should.equal(fields[5].key, 'age');
+        should.equal(fields[6].key, 'tagline');
+        should.equal(fields[6].type, 'string');
+      });
+    });
+
+    it('KEY_pre_custom_search_result_fields & KEY_post_custom_search_result_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_pre_custom_search_result_fields_disabled',
+        'movie_pre_custom_search_result_fields'
+      );
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_post_custom_search_result_fields_disabled',
+        'movie_post_custom_search_result_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.outputFields'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return app(input).then(output => {
+        const fields = output.results;
+        should.equal(fields.length, 7);
+        should.equal(fields[0].key, 'id');
+        should.equal(fields[1].key, 'title');
+        should.equal(fields[2].key, 'genre');
+        should.equal(fields[3].key, 'id');
+        should.equal(fields[4].key, 'color');
+        should.equal(fields[5].key, 'age');
+        should.equal(fields[6].key, 'tagline');
+        should.equal(fields[6].type, 'string');
+      });
+    });
+
+    it('KEY_custom_search_result_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_custom_search_result_fields_disabled',
+        'movie_custom_search_result_fields'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
       return app(input).then(output => {


### PR DESCRIPTION
Adds support for search custom fields scripting, i.e., the following scripting methods:

```
KEY_pre_custom_search_fields
KEY_post_custom_search_fields
KEY_custom_search_fields

KEY_pre_custom_search_result_fields
KEY_post_custom_search_result_fields
KEY_custom_search_result_fields
```

Reuses a lot of things that were already done in #20.