### PR TITLE
Search scripting

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -87,7 +87,7 @@ const addInputData = (event, bundle, convertedBundle) => {
     convertedBundle.search_fields = bundle.inputData;
 
     if (event.name.startsWith('search.resource')) {
-      convertedBundle.read_fields = event.results;
+      convertedBundle.read_fields = event.results || bundle.inputData;
       convertedBundle.read_context = bundle.inputData;
     }
   }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 const _ = require('lodash');
 
+const cleaner = require('zapier-platform-core/src/tools/cleaner');
+
 const bundleConverter = require('./bundle');
 
 const FIELD_TYPE_CONVERT_MAP = {
@@ -584,6 +586,9 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
     const url = legacyProps.url;
 
     bundle.request.url = url;
+
+    const bank = cleaner.createBundleBank(undefined, { bundle: bundle });
+    bundle.request = cleaner.recurseReplaceBank(bundle.request, bank);
 
     return runEventCombo(
       bundle,

--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ const parseFinalResult = (result, event) => {
   return result;
 };
 
+const replaceCurliesInRequest = (request, bundle) => {
+  const bank = cleaner.createBundleBank(undefined, { bundle: bundle });
+  return cleaner.recurseReplaceBank(request, bank);
+};
+
 const compileLegacyScriptingSource = source => {
   const { DOMParser, XMLSerializer } = require('xmldom');
   const {
@@ -256,6 +261,10 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
       },
       options
     );
+
+    if (bundle.request) {
+      bundle.request = replaceCurliesInRequest(bundle.request, bundle);
+    }
 
     let promise;
 
@@ -586,9 +595,6 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
     const url = legacyProps.url;
 
     bundle.request.url = url;
-
-    const bank = cleaner.createBundleBank(undefined, { bundle: bundle });
-    bundle.request = cleaner.recurseReplaceBank(bundle.request, bank);
 
     return runEventCombo(
       bundle,

--- a/index.js
+++ b/index.js
@@ -578,6 +578,23 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
     return runCustomFields(bundle, key, 'create.output', url);
   };
 
+  const runSearch = (bundle, key) => {
+    const legacyProps =
+      _.get(app, `searches.${key}.operation.legacyProperties`) || {};
+    const url = legacyProps.url;
+
+    bundle.request.url = url;
+
+    return runEventCombo(
+      bundle,
+      key,
+      'search.pre',
+      'search.post',
+      'search.search',
+      { ensureArray: 'first' }
+    );
+  };
+
   const runSearchInputFields = (bundle, key) => {
     const url = _.get(
       app,
@@ -637,13 +654,14 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
           return runCreateInputFields(bundle, key);
         case 'create.output':
           return runCreateOutputFields(bundle, key);
+        case 'search':
+          return runSearch(bundle, key);
         case 'search.input':
           return runSearchInputFields(bundle, key);
         case 'search.output':
           return runSearchOutputFields(bundle, key);
 
         // TODO: Add support for these:
-        // search
         // search.resource
       }
       throw new Error(`unrecognizable typeOf '${typeOf}'`);

--- a/index.js
+++ b/index.js
@@ -257,8 +257,7 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
         parseResponse: true,
         ensureArray: false,
 
-        resetRequestForFullMethod: false,
-        parseResponseForPostMethod: false
+        resetRequestForFullMethod: false
       },
       options
     );
@@ -314,13 +313,9 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
 
       const postMethod = postMethodName ? Zap[postMethodName] : null;
       if (postMethod) {
-        promise = promise.then(response => {
-          const event = { key, name: postEventName, response };
-          if (options.parseResponseForPostMethod) {
-            event.results = zobj.JSON.parse(response.content);
-          }
-          return runEvent(event, zobj, bundle);
-        });
+        promise = promise.then(response =>
+          runEvent({ key, name: postEventName, response }, zobj, bundle)
+        );
       } else {
         promise = promise.then(response => zobj.JSON.parse(response.content));
       }

--- a/test/auth-json-server.js
+++ b/test/auth-json-server.js
@@ -1,0 +1,6 @@
+const AUTH_JSON_SERVER_URL =
+  process.env.AUTH_JSON_SERVER_URL || 'https://auth-json-server.zapier.ninja';
+
+module.exports = {
+  AUTH_JSON_SERVER_URL
+};

--- a/test/example-app/api-key-auth.js
+++ b/test/example-app/api-key-auth.js
@@ -1,8 +1,8 @@
-'use strict';
+const { AUTH_JSON_SERVER_URL } = require('../auth-json-server');
 
 const testAuthSource = `
   const responsePromise = z.request({
-    url: 'https://auth-json-server.zapier.ninja/me'
+    url: '${AUTH_JSON_SERVER_URL}/me'
   });
   return responsePromise.then(response => {
     if (response.status !== 200) {

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -1,3 +1,5 @@
+const { AUTH_JSON_SERVER_URL } = require('../auth-json-server');
+
 const legacyScriptingSource = `
     var Zap = {
       get_session_info: function(bundle) {
@@ -9,7 +11,7 @@ const legacyScriptingSource = `
               'Accept': 'application/json',
               'Authorization': 'Basic ' + encodedCredentials
           },
-          url: 'https://auth-json-server.zapier.ninja/me'
+          url: '${AUTH_JSON_SERVER_URL}/me'
         });
 
         if (response.status_code !== 200) {
@@ -50,7 +52,7 @@ const legacyScriptingSource = `
        */
 
       contact_full_poll: function(bundle) {
-        bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/users';
         var response = z.request(bundle.request);
         var contacts = z.JSON.parse(response.content);
         contacts[0].name = 'Patched by KEY_poll!';
@@ -73,7 +75,7 @@ const legacyScriptingSource = `
       },
 
       contact_pre_pre_poll: function(bundle) {
-        bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/users';
         bundle.request.params.id = 3;
         return bundle.request;
       },
@@ -85,7 +87,7 @@ const legacyScriptingSource = `
       },
 
       contact_pre_post_pre_poll: function(bundle) {
-        bundle.request.url = 'https://auth-json-server.zapier.ninja/users';
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/users';
         bundle.request.params.id = 4;
         return bundle.request;
       },
@@ -228,7 +230,7 @@ const legacyScriptingSource = `
       // To be replaced with 'movie_custom_action_fields' at runtime
       movie_custom_action_fields_disabled: function(bundle) {
         // bundle.request.url should be an empty string to start with
-        bundle.request.url += 'https://auth-json-server.zapier.ninja/input-fields';
+        bundle.request.url += '${AUTH_JSON_SERVER_URL}/input-fields';
         var response = z.request(bundle.request);
         var fields = z.JSON.parse(response.content);
         fields.push({
@@ -259,7 +261,7 @@ const legacyScriptingSource = `
       // To be replaced with 'movie_custom_action_result_fields' at runtime
       movie_custom_action_result_fields_disabled: function(bundle, callback) {
         // bundle.request.url should be an empty string to start with
-        bundle.request.url += 'https://auth-json-server.zapier.ninja/output-fields';
+        bundle.request.url += '${AUTH_JSON_SERVER_URL}/output-fields';
         z.request(bundle.request, function(err, response) {
           if (err) {
             callback(err, response);
@@ -301,6 +303,28 @@ const legacyScriptingSource = `
         return results;
       },
 
+      // To be replaced with 'movie_pre_read_resource' at runtime
+      movie_pre_read_resource_disabled: function(bundle) {
+        bundle.request.url = bundle.request.url.replace('/movie/', '/movies/');
+        return bundle.request;
+      },
+
+      // To be replaced with 'movie_post_read_resource' at runtime
+      movie_post_read_resource_disabled: function(bundle) {
+        var movie = z.JSON.parse(bundle.response.content);
+        movie.title += ' (movie_post_read_resource was here)';
+        movie.anotherId = bundle.read_fields.id;
+        return movie;
+      },
+
+      movie_read_resource_disabled: function(bundle) {
+        bundle.request.url = bundle.request.url.replace('/movie/', '/movies/');
+        var response = z.request(bundle.request);
+        var movie = z.JSON.parse(response.content);
+        movie.title += ' (movie_read_resource was here)';
+        return movie;
+      },
+
       // To be replaced with 'movie_pre_custom_search_fields' at runtime
       movie_pre_custom_search_fields_disabled: function(bundle) {
         bundle.request.url += 's';
@@ -321,7 +345,7 @@ const legacyScriptingSource = `
       // To be replaced with 'movie_custom_search_fields' at runtime
       movie_custom_search_fields_disabled: function(bundle) {
         // bundle.request.url should be an empty string to start with
-        bundle.request.url += 'https://auth-json-server.zapier.ninja/input-fields';
+        bundle.request.url += '${AUTH_JSON_SERVER_URL}/input-fields';
         var response = z.request(bundle.request);
         var fields = z.JSON.parse(response.content);
         fields.push({
@@ -352,7 +376,7 @@ const legacyScriptingSource = `
       // To be replaced with 'movie_custom_search_result_fields' at runtime
       movie_custom_search_result_fields_disabled: function(bundle, callback) {
         // bundle.request.url should be an empty string to start with
-        bundle.request.url += 'https://auth-json-server.zapier.ninja/output-fields';
+        bundle.request.url += '${AUTH_JSON_SERVER_URL}/output-fields';
         z.request(bundle.request, function(err, response) {
           if (err) {
             callback(err, response);
@@ -399,7 +423,7 @@ const ContactTrigger_full = {
     legacyProperties: {
       // Misses an 's' at the end on purpose for KEY_pre_custom_trigger_fields
       // to fix
-      outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field'
+      outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
     }
   }
 };
@@ -425,7 +449,7 @@ const ContactTrigger_post = {
   },
   operation: {
     legacyProperties: {
-      url: 'https://auth-json-server.zapier.ninja/users'
+      url: `${AUTH_JSON_SERVER_URL}/users`
     },
     perform: {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'contact_post');"
@@ -497,7 +521,7 @@ const TestTrigger = {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'test');"
     },
     legacyProperties: {
-      url: 'https://auth-json-server.zapier.ninja/me'
+      url: `${AUTH_JSON_SERVER_URL}/me`
     }
   }
 };
@@ -530,9 +554,9 @@ const MovieCreate = {
     ],
     legacyProperties: {
       // The URLs miss an 's' at the end on purpose for scripting to fix it
-      url: 'https://auth-json-server.zapier.ninja/movie',
-      inputFieldsUrl: 'https://auth-json-server.zapier.ninja/input-field',
-      outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field',
+      url: `${AUTH_JSON_SERVER_URL}/movie`,
+      inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
+      outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`,
       fieldsExcludedFromBody: ['title']
     }
   }
@@ -547,6 +571,10 @@ const MovieSearch = {
   operation: {
     perform: {
       source: "return z.legacyScripting.run(bundle, 'search', 'movie');"
+    },
+    performGet: {
+      source:
+        "return z.legacyScripting.run(bundle, 'search.resource', 'movie');"
     },
     inputFields: [
       { key: 'query', label: 'Query', type: 'string' },
@@ -566,10 +594,10 @@ const MovieSearch = {
     legacyProperties: {
       // The URLs miss an 's' at the end of the resource names on purpose for
       // scripting to fix it
-      url:
-        'https://auth-json-server.zapier.ninja/movie?q={{bundle.inputData.query}}',
-      inputFieldsUrl: 'https://auth-json-server.zapier.ninja/input-field',
-      outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field'
+      url: `${AUTH_JSON_SERVER_URL}/movie?q={{bundle.inputData.query}}`,
+      resourceUrl: `${AUTH_JSON_SERVER_URL}/movie/{{bundle.inputData.id}}`,
+      inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
+      outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
     }
   }
 };

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -281,19 +281,23 @@ const legacyScriptingSource = `
 
       // To be replaced with 'movie_pre_search' at runtime
       movie_pre_search_disabled: function(bundle) {
+        bundle.request.url = bundle.request.url.replace('movie?', 'movies?');
+        return bundle.request;
       },
 
       // To be replaced with 'movie_post_search' at runtime
       movie_post_search_disabled: function(bundle) {
+        var results = z.JSON.parse(bundle.response.content);
+        results[0].title += ' (movie_post_search was here)';
+        return results;
       },
 
+      // To be replaced with 'movie_search' at runtime
       movie_search_disabled: function(bundle) {
+        bundle.request.url = bundle.request.url.replace('movie?', 'movies?');
         var response = z.request(bundle.request);
         var results = z.JSON.parse(response.content);
-        results.push({
-          id: 999,
-          title: 'The Post'
-        });
+        results[0].title += ' (movie_search was here)';
         return results;
       },
 
@@ -560,9 +564,10 @@ const MovieSearch = {
       }
     ],
     legacyProperties: {
-      url: 'https://auth-json-server.zapier.ninja/movies?q={{bundle.inputData.query}}',
-
-      // The URLs miss an 's' at the end on purpose for scripting to fix it
+      // The URLs miss an 's' at the end of the resource names on purpose for
+      // scripting to fix it
+      url:
+        'https://auth-json-server.zapier.ninja/movie?q={{bundle.inputData.query}}',
       inputFieldsUrl: 'https://auth-json-server.zapier.ninja/input-field',
       outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field'
     }

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -560,7 +560,7 @@ const MovieSearch = {
       }
     ],
     legacyProperties: {
-      url: 'https://auth-json-server.zapier.ninja/movies?q={{bundle.inputdata.query}}',
+      url: 'https://auth-json-server.zapier.ninja/movies?q={{bundle.inputData.query}}',
 
       // The URLs miss an 's' at the end on purpose for scripting to fix it
       inputFieldsUrl: 'https://auth-json-server.zapier.ninja/input-field',

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -305,7 +305,9 @@ const legacyScriptingSource = `
 
       // To be replaced with 'movie_pre_read_resource' at runtime
       movie_pre_read_resource_disabled: function(bundle) {
-        bundle.request.url = bundle.request.url.replace('/movie/', '/movies/');
+        // Replace '/movie/123' with '/movies/123'
+        bundle.request.url =
+          bundle.request.url.replace(/\\/movie\\/\\d+/, '/movies/' + bundle.read_fields.id);
         return bundle.request;
       },
 

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -279,6 +279,24 @@ const legacyScriptingSource = `
        * Search
        */
 
+      // To be replaced with 'movie_pre_search' at runtime
+      movie_pre_search_disabled: function(bundle) {
+      },
+
+      // To be replaced with 'movie_post_search' at runtime
+      movie_post_search_disabled: function(bundle) {
+      },
+
+      movie_search_disabled: function(bundle) {
+        var response = z.request(bundle.request);
+        var results = z.JSON.parse(response.content);
+        results.push({
+          id: 999,
+          title: 'The Post'
+        });
+        return results;
+      },
+
       // To be replaced with 'movie_pre_custom_search_fields' at runtime
       movie_pre_custom_search_fields_disabled: function(bundle) {
         bundle.request.url += 's';
@@ -527,7 +545,7 @@ const MovieSearch = {
       source: "return z.legacyScripting.run(bundle, 'search', 'movie');"
     },
     inputFields: [
-      { key: 'title', label: 'Title', type: 'string' },
+      { key: 'query', label: 'Query', type: 'string' },
       {
         source: "return z.legacyScripting.run(bundle, 'search.input', 'movie');"
       }
@@ -542,8 +560,9 @@ const MovieSearch = {
       }
     ],
     legacyProperties: {
+      url: 'https://auth-json-server.zapier.ninja/movies?q={{bundle.inputdata.query}}',
+
       // The URLs miss an 's' at the end on purpose for scripting to fix it
-      url: 'https://auth-json-server.zapier.ninja/movie',
       inputFieldsUrl: 'https://auth-json-server.zapier.ninja/input-field',
       outputFieldsUrl: 'https://auth-json-server.zapier.ninja/output-field'
     }

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -423,8 +423,9 @@ const ContactTrigger_full = {
       }
     ],
     legacyProperties: {
-      // Misses an 's' at the end on purpose for KEY_pre_custom_trigger_fields
-      // to fix
+      // The URL misses an 's' at the end of the resource names. That is,
+      // 'output-field' where it should be 'output-fields'. Done purposely for
+      // scripting to fix it.
       outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
     }
   }
@@ -555,7 +556,9 @@ const MovieCreate = {
       }
     ],
     legacyProperties: {
-      // The URLs miss an 's' at the end on purpose for scripting to fix it
+      // These URLs miss an 's' at the end of the resource names. That is,
+      // 'movie' where it should be 'movies' and 'input-field' where it should
+      // be 'input-fields'. Done purposely for scripting to fix it.
       url: `${AUTH_JSON_SERVER_URL}/movie`,
       inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
       outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`,
@@ -594,8 +597,9 @@ const MovieSearch = {
       }
     ],
     legacyProperties: {
-      // The URLs miss an 's' at the end of the resource names on purpose for
-      // scripting to fix it
+      // These URLs miss an 's' at the end of the resource names. That is,
+      // 'movie' where it should be 'movies' and 'input-field' where it should
+      // be 'input-fields'. Done purposely for scripting to fix it.
       url: `${AUTH_JSON_SERVER_URL}/movie?q={{bundle.inputData.query}}`,
       resourceUrl: `${AUTH_JSON_SERVER_URL}/movie/{{bundle.inputData.id}}`,
       inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,

--- a/test/example-app/oauth2.js
+++ b/test/example-app/oauth2.js
@@ -1,8 +1,8 @@
-'use strict';
+const { AUTH_JSON_SERVER_URL } = require('../auth-json-server');
 
 const testAuthSource = `
   const responsePromise = z.request({
-    url: 'https://auth-json-server.zapier.ninja/me'
+    url: '${AUTH_JSON_SERVER_URL}/me'
   });
   return responsePromise.then(response => {
     if (response.status !== 200) {
@@ -44,12 +44,12 @@ module.exports = {
     oauth2Config: {
       legacyProperties: {
         // Incomplete URLs on purpose to test pre_oauthv2_token
-        accessTokenUrl: 'https://auth-json-server.zapier.ninja/oauth/access-',
-        refreshTokenUrl: 'https://auth-json-server.zapier.ninja/oauth/refresh-'
+        accessTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/access-`,
+        refreshTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/refresh-`
       },
       authorizeUrl: {
         method: 'GET',
-        url: 'https://auth-json-server.zapier.ninja/oauth/authorize',
+        url: `${AUTH_JSON_SERVER_URL}/oauth/authorize`,
         params: {
           client_id: '{{process.env.CLIENT_ID}}',
           state: '{{bundle.inputData.state}}',
@@ -66,7 +66,9 @@ module.exports = {
       autoRefresh: true
     }
   },
-  beforeRequest: [{ source: maybeIncludeAuthSource, args: ['request', 'z', 'bundle'] }]
+  beforeRequest: [
+    { source: maybeIncludeAuthSource, args: ['request', 'z', 'bundle'] }
+  ]
 
   // We don't need afterResponse to refresh auth as core appends one
   // automatically when autoRefresh is true

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1084,7 +1084,7 @@ describe('Integration Test', () => {
   });
 
   describe('search', () => {
-    it.only('scriptingless perform', () => {
+    it('scriptingless perform', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -1095,16 +1095,18 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 3',
+        query: 'title 10',
       };
       return app(input).then(output => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
-        should.equal(movie.id, 3);
-        should.equal(movie.title, 'title 3');
+        should.equal(movie.id, 10);
+        should.equal(movie.title, 'title 10');
       });
     });
+
+    // TODO: search scripting methods
 
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1086,6 +1086,9 @@ describe('Integration Test', () => {
   describe('search', () => {
     it('scriptingless perform', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      const legacyProps =
+        appDefWithAuth.searches.movie.operation.legacyProperties;
+      legacyProps.url = legacyProps.url.replace('movie?', 'movies?');
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
 
@@ -1095,7 +1098,7 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 10',
+        query: 'title 10'
       };
       return app(input).then(output => {
         output.results.length.should.equal(1);
@@ -1106,7 +1109,116 @@ describe('Integration Test', () => {
       });
     });
 
-    // TODO: search scripting methods
+    it('KEY_pre_search', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_pre_search_disabled',
+        'movie_pre_search'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        query: 'title 20'
+      };
+      return app(input).then(output => {
+        output.results.length.should.equal(1);
+
+        const movie = output.results[0];
+        should.equal(movie.id, 20);
+        should.equal(movie.title, 'title 20');
+      });
+    });
+
+    it('KEY_post_search', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      const legacyProps =
+        appDefWithAuth.searches.movie.operation.legacyProperties;
+      legacyProps.url = legacyProps.url.replace('movie?', 'movies?');
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_post_search_disabled',
+        'movie_post_search'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        query: 'title 20'
+      };
+      return app(input).then(output => {
+        output.results.length.should.equal(1);
+
+        const movie = output.results[0];
+        should.equal(movie.id, 20);
+        should.equal(movie.title, 'title 20 (movie_post_search was here)');
+      });
+    });
+
+    it('KEY_pre_search & KEY_post_search', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_pre_search_disabled',
+        'movie_pre_search'
+      );
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_post_search_disabled',
+        'movie_post_search'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        query: 'title 20'
+      };
+      return app(input).then(output => {
+        output.results.length.should.equal(1);
+
+        const movie = output.results[0];
+        should.equal(movie.id, 20);
+        should.equal(movie.title, 'title 20 (movie_post_search was here)');
+      });
+    });
+
+    it('KEY_search', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+        'movie_search_disabled',
+        'movie_search'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        query: 'title 12'
+      };
+      return app(input).then(output => {
+        output.results.length.should.equal(1);
+
+        const movie = output.results[0];
+        should.equal(movie.id, 12);
+        should.equal(movie.title, 'title 12 (movie_search was here)');
+      });
+    });
 
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1084,6 +1084,28 @@ describe('Integration Test', () => {
   });
 
   describe('search', () => {
+    it.only('scriptingless perform', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        query: 'title 3',
+      };
+      return app(input).then(output => {
+        output.results.length.should.equal(1);
+
+        const movie = output.results[0];
+        should.equal(movie.id, 3);
+        should.equal(movie.title, 'title 3');
+      });
+    });
+
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.searches.movie.operation.legacyProperties.inputFieldsUrl +=
@@ -1100,7 +1122,7 @@ describe('Integration Test', () => {
       return app(input).then(output => {
         const fields = output.results;
         should.equal(fields.length, 2);
-        should.equal(fields[0].key, 'title');
+        should.equal(fields[0].key, 'query');
         should.equal(fields[1].key, 'luckyNumber');
       });
     });
@@ -1123,7 +1145,7 @@ describe('Integration Test', () => {
       return app(input).then(output => {
         const fields = output.results;
         should.equal(fields.length, 2);
-        should.equal(fields[0].key, 'title');
+        should.equal(fields[0].key, 'query');
         should.equal(fields[1].key, 'luckyNumber');
       });
     });
@@ -1148,7 +1170,7 @@ describe('Integration Test', () => {
       return app(input).then(output => {
         const fields = output.results;
         should.equal(fields.length, 3);
-        should.equal(fields[0].key, 'title');
+        should.equal(fields[0].key, 'query');
         should.equal(fields[1].key, 'luckyNumber');
         should.equal(fields[2].key, 'year');
         should.equal(fields[2].type, 'integer');
@@ -1177,7 +1199,7 @@ describe('Integration Test', () => {
       return app(input).then(output => {
         const fields = output.results;
         should.equal(fields.length, 3);
-        should.equal(fields[0].key, 'title');
+        should.equal(fields[0].key, 'query');
         should.equal(fields[1].key, 'luckyNumber');
         should.equal(fields[2].key, 'year');
         should.equal(fields[2].type, 'integer');
@@ -1202,7 +1224,7 @@ describe('Integration Test', () => {
       return app(input).then(output => {
         const fields = output.results;
         should.equal(fields.length, 3);
-        should.equal(fields[0].key, 'title');
+        should.equal(fields[0].key, 'query');
         should.equal(fields[1].key, 'luckyNumber');
         should.equal(fields[2].key, 'year');
         should.equal(fields[2].type, 'integer');


### PR DESCRIPTION
Adds support for the following search scripting methods:

```
KEY_pre_search
KEY_post_search
KEY_search

KEY_pre_read_resource
KEY_post_read_resource
KEY_read_resource
```

This allows us to run the search scripting by calling `z.legacyScripting.run(bundle, 'search', 'KEY')` and `z.legacyScripting.run(bundle, 'search.resource', 'KEY')` in a CLI app.

Also replaces all occurrences of `https://auth-json-server.zapier.ninja` with `AUTH_JSON_SERVER_URL` constant, making it possible to test with a local hosted [auth-json-server](https://github.com/zapier/auth-json-server).