### PR TITLE
Add support for z.dehydrateFile

### DIFF
--- a/exceptions.js
+++ b/exceptions.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const util = require('util');
 
 // Make some of the errors we'll use!
-const createError = (name) => {
+const createError = name => {
   const NewError = function(message) {
     this.name = name;
     this.message = message || '';
@@ -20,12 +20,17 @@ const names = [
   'StopRequestError',
   'ExpiredAuthError',
   'RefreshAuthError',
+  'DehydrateError'
 ];
 
-const cliErrors = _.reduce(names, (error, name) => {
-  error[name] = createError(name);
-  return error;
-}, {});
+const cliErrors = _.reduce(
+  names,
+  (error, name) => {
+    error[name] = createError(name);
+    return error;
+  },
+  {}
+);
 
 const exceptions = {
   ErrorException: Error,
@@ -34,6 +39,7 @@ const exceptions = {
   ExpiredAuthException: cliErrors.ExpiredAuthError,
   RefreshTokenException: cliErrors.RefreshAuthError,
   InvalidSessionException: cliErrors.RefreshAuthError, // In CLI, RefreshAuthError works the same for both OAuth and Session
+  DehydrateException: cliErrors.DehydrateError
 };
 
 module.exports = exceptions;

--- a/index.js
+++ b/index.js
@@ -735,6 +735,15 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
     return runCustomFields(bundle, key, 'search.output', url);
   };
 
+  const runHydrateFile = bundle => {
+    const meta = bundle.inputData.meta || {};
+    const requestOptions = bundle.inputData.request || {};
+    requestOptions.url = bundle.inputData.url || requestOptions.url;
+    requestOptions.raw = true;
+    const filePromise = zobj.request(requestOptions);
+    return zobj.stashFile(filePromise, meta.length, meta.name);
+  };
+
   // core exposes this function as z.legacyScripting.run() method that we can
   // run legacy scripting easily like z.legacyScripting.run(bundle, 'trigger', 'KEY')
   // in CLI to simulate how WB backend runs legacy scripting.
@@ -786,6 +795,8 @@ const legacyScriptingRunner = (Zap, zobj, app) => {
           return runSearchInputFields(bundle, key);
         case 'search.output':
           return runSearchOutputFields(bundle, key);
+        case 'hydrate.file':
+          return runHydrateFile(bundle);
       }
       throw new Error(`unrecognizable typeOf '${typeOf}'`);
     });

--- a/index.js
+++ b/index.js
@@ -770,8 +770,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     const requestOptions = bundle.inputData.request || {};
 
     // Legacy z.dehydrateFile(url, request, meta) behavior: if request argument is
-    // provided, the dev is responsible for doing auth themselves, so we don't want to
-    // run app's http middlewares by using an internal request client.
+    // provided, the dev is responsible for doing auth themselves, so we use an internal
+    // request client to avoid running the app's http middlewares.
     const request = _.isEmpty(requestOptions)
       ? zcli.request
       : createInternalRequestClient(input);

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -174,10 +174,14 @@ const legacyScriptingSource = `
           // Just a JSON file, not a real trailer
           movie.trailer = z.dehydrateFile(url, {
             params: { id: movie.id }
+          }, {
+            name: 'movie ' + movie.id + '.json',
+            length: 1234
           });
           return movie;
         });
       },
+
 
       /*
        * Create/Action
@@ -731,6 +735,11 @@ const App = {
   },
   searches: {
     [MovieSearch.key]: MovieSearch
+  },
+  hydrators: {
+    legacyFileHydrator: {
+      source: "return z.legacyScripting.run(bundle, 'hydrate.file');"
+    }
   },
   legacyProperties: {
     subscribeUrl: 'http://zapier-httpbin.herokuapp.com/post',

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -167,6 +167,18 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_post_poll_file_dehydration: function(bundle) {
+        var movies = z.JSON.parse(bundle.response.content);
+        var url = '${AUTH_JSON_SERVER_URL}/movies';
+        return movies.map(movie => {
+          // Just a JSON file, not a real trailer
+          movie.trailer = z.dehydrateFile(url, {
+            params: { id: movie.id }
+          });
+          return movie;
+        });
+      },
+
       /*
        * Create/Action
        */
@@ -586,6 +598,21 @@ const TestTrigger = {
   }
 };
 
+const MovieTrigger = {
+  key: 'movie',
+  display: {
+    label: 'New Movie'
+  },
+  operation: {
+    perform: {
+      source: "return z.legacyScripting.run(bundle, 'trigger', 'movie');"
+    },
+    legacyProperties: {
+      url: `${AUTH_JSON_SERVER_URL}/movies`
+    }
+  }
+};
+
 const MovieCreate = {
   key: 'movie',
   noun: 'Movie',
@@ -695,7 +722,8 @@ const App = {
     [ContactTrigger_pre_post.key]: ContactTrigger_pre_post,
     [ContactHook_scriptingless.key]: ContactHook_scriptingless,
     [ContactHook_scripting.key]: ContactHook_scripting,
-    [TestTrigger.key]: TestTrigger
+    [TestTrigger.key]: TestTrigger,
+    [MovieTrigger.key]: MovieTrigger
   },
   creates: {
     [MovieCreate.key]: MovieCreate,

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -338,11 +338,16 @@ describe('Integration Test', () => {
           movie.trailer.should.startWith('hydrate|||');
           movie.trailer.should.endWith('|||hydrate');
 
-          const trailer = JSON.parse(movie.trailer.split('|||')[1]);
-          should.equal(trailer.type, 'method');
-          should.equal(trailer.method, 'hydrators._legacyHydrateFile');
-          should.equal(trailer.bundle.url, `${AUTH_JSON_SERVER_URL}/movies`);
-          should.deepEqual(trailer.bundle.request.params, { id: movie.id });
+          const payload = JSON.parse(movie.trailer.split('|||')[1]);
+          should.equal(payload.type, 'file');
+          should.equal(payload.method, 'hydrators.legacyFileHydrator');
+          should.equal(
+            payload.bundle.url,
+            'https://auth-json-server.zapier.ninja/movies'
+          );
+          should.equal(payload.bundle.request.params.id, movie.id);
+          should.equal(payload.bundle.meta.name, `movie ${movie.id}.json`);
+          should.equal(payload.bundle.meta.length, 1234);
         });
       });
     });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1501,6 +1501,7 @@ describe('Integration Test', () => {
           const buffer = await response.buffer();
           const content = buffer.toString('utf8');
           return {
+            response,
             content: JSON.parse(content),
             knownLength,
             filename,
@@ -1528,6 +1529,7 @@ describe('Integration Test', () => {
         };
         return app(input).then(output => {
           const {
+            response,
             content,
             knownLength,
             filename,
@@ -1537,6 +1539,10 @@ describe('Integration Test', () => {
           should.not.exist(knownLength);
           should.not.exist(filename);
           should.not.exist(contentType);
+
+          // Make sure prepareResponse middleware was run
+          response.getHeader.should.be.Function();
+          should.equal(response.getHeader('content-type'), 'application/json');
         });
       });
 
@@ -1561,6 +1567,7 @@ describe('Integration Test', () => {
         };
         return app(input).then(output => {
           const {
+            response,
             content,
             knownLength,
             filename,
@@ -1573,6 +1580,10 @@ describe('Integration Test', () => {
           should.not.exist(knownLength);
           should.not.exist(filename);
           should.not.exist(contentType);
+
+          // Make sure prepareResponse middleware was run
+          response.getHeader.should.be.Function();
+          should.equal(response.getHeader('content-type'), 'application/json');
         });
       });
 
@@ -1601,6 +1612,7 @@ describe('Integration Test', () => {
         };
         return app(input).then(output => {
           const {
+            response,
             content,
             knownLength,
             filename,
@@ -1613,6 +1625,10 @@ describe('Integration Test', () => {
           should.equal(knownLength, 1234);
           should.equal(filename, 'hello.json');
           should.not.exist(contentType);
+
+          // Make sure prepareResponse middleware was run
+          response.getHeader.should.be.Function();
+          should.equal(response.getHeader('content-type'), 'application/json');
         });
       });
     });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -14,6 +14,26 @@ const withAuth = (appDef, authConfig) => {
   return _.extend(_.cloneDeep(appDef), _.cloneDeep(authConfig));
 };
 
+// XXX: Allow to add custom app befores. Kind of hacky, but we can remove this once
+// https://github.com/zapier/zapier-platform-core/pull/119 is shipped
+const createAppWithCustomBefores = (appRaw, customBefores) => {
+  const addAppContext = require('zapier-platform-core/src/app-middlewares/before/add-app-context');
+  const injectZObject = require('zapier-platform-core/src/app-middlewares/before/z-object');
+  const checkOutput = require('zapier-platform-core/src/app-middlewares/after/checks');
+  const largeResponseCachePointer = require('zapier-platform-core/src/app-middlewares/after/large-response-cacher');
+  const waitForPromises = require('zapier-platform-core/src/app-middlewares/after/wait-for-promises');
+  const createCommandHandler = require('zapier-platform-core/src/create-command-handler');
+  const applyMiddleware = require('zapier-platform-core/src/middleware');
+
+  const frozenCompiledApp = schemaTools.prepareApp(appRaw);
+
+  const befores = [addAppContext, injectZObject].concat(customBefores || []);
+  const afters = [checkOutput, largeResponseCachePointer, waitForPromises];
+
+  const app = createCommandHandler(frozenCompiledApp);
+  return applyMiddleware(befores, afters, app);
+};
+
 describe('Integration Test', () => {
   const testLogger = (/* message, data */) => {
     // console.log(message, data);
@@ -1464,6 +1484,136 @@ describe('Integration Test', () => {
 
         const data = JSON.parse(output.results.data);
         should.equal(data.filename, 'dont.care');
+      });
+    });
+
+    describe('legacyFileHydrator', () => {
+      const mockFileStahser = input => {
+        // Mock z.stashFile to do nothing but return file content and meta
+        input.z.stashFile = async (
+          filePromise,
+          knownLength,
+          filename,
+          contentType
+        ) => {
+          // Assuming filePromise gives us a JSON string
+          const response = await filePromise;
+          const buffer = await response.buffer();
+          const content = buffer.toString('utf8');
+          return {
+            content: JSON.parse(content),
+            knownLength,
+            filename,
+            contentType
+          };
+        };
+        return input;
+      };
+
+      it('should send auth when no request options', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createAppWithCustomBefores(appDefWithAuth, [
+          mockFileStahser
+        ]);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyFileHydrator'
+        );
+        input.bundle.authData = { api_key: 'super secret' };
+        input.bundle.inputData = {
+          // This endpoint echoes what we send to it, so we know if auth info was sent
+          url: 'https://zapier-httpbin.herokuapp.com/get'
+        };
+        return app(input).then(output => {
+          const {
+            content,
+            knownLength,
+            filename,
+            contentType
+          } = output.results;
+          should.equal(content.headers['X-Api-Key'], 'super secret');
+          should.not.exist(knownLength);
+          should.not.exist(filename);
+          should.not.exist(contentType);
+        });
+      });
+
+      it('should not send auth when request options are present', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createAppWithCustomBefores(appDefWithAuth, [
+          mockFileStahser
+        ]);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyFileHydrator'
+        );
+        input.bundle.authData = { api_key: 'super secret' };
+        input.bundle.inputData = {
+          // This endpoint echoes what we send to it, so we know if auth info was sent
+          url: 'https://zapier-httpbin.herokuapp.com/get',
+          request: {
+            params: { foo: 1, bar: 'hello' }
+          }
+        };
+        return app(input).then(output => {
+          const {
+            content,
+            knownLength,
+            filename,
+            contentType
+          } = output.results;
+
+          should.equal(content.args.foo, '1');
+          should.equal(content.args.bar, 'hello');
+          should.not.exist(content.headers['X-Api-Key']);
+          should.not.exist(knownLength);
+          should.not.exist(filename);
+          should.not.exist(contentType);
+        });
+      });
+
+      it('should send file meta', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createAppWithCustomBefores(appDefWithAuth, [
+          mockFileStahser
+        ]);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyFileHydrator'
+        );
+        input.bundle.authData = { api_key: 'super secret' };
+        input.bundle.inputData = {
+          // This endpoint echoes what we send to it, so we know if auth info was sent
+          url: 'https://zapier-httpbin.herokuapp.com/get',
+          request: {
+            params: { foo: 1, bar: 'hello' }
+          },
+          meta: {
+            length: 1234,
+            name: 'hello.json'
+          }
+        };
+        return app(input).then(output => {
+          const {
+            content,
+            knownLength,
+            filename,
+            contentType
+          } = output.results;
+
+          should.equal(content.args.foo, '1');
+          should.equal(content.args.bar, 'hello');
+          should.not.exist(content.headers['X-Api-Key']);
+          should.equal(knownLength, 1234);
+          should.equal(filename, 'hello.json');
+          should.not.exist(contentType);
+        });
       });
     });
   });

--- a/test/zfactory.js
+++ b/test/zfactory.js
@@ -1,6 +1,6 @@
 const should = require('should');
 
-const z = require('../z');
+const z = require('../zfactory')();
 
 describe('z', () => {
   it('z.hash', done => {

--- a/z.js
+++ b/z.js
@@ -158,6 +158,8 @@ const z = {
       JSON.stringify({
         type: 'method',
         method: 'hydrators._legacyHydrateFile',
+
+        // will be available as bundle.inputData actually
         bundle: {
           url,
           request: requestOptions,

--- a/zfactory.js
+++ b/zfactory.js
@@ -4,8 +4,6 @@ const _ = require('lodash');
 const deasync = require('deasync');
 const request = require('request');
 
-const exceptions = require('./exceptions');
-
 // Converts WB `bundle.request` format to something `request` can use
 const convertBundleRequest = bundleOrBundleRequest => {
   bundleOrBundleRequest = _.extend({}, bundleOrBundleRequest);
@@ -65,7 +63,7 @@ const convertResponse = response => {
 
 const syncRequest = deasync(request);
 
-const zfactory = zcli => {
+const zfactory = (zcli, app) => {
   const AWS = () => {
     // Direct require breaks the build as the module isn't found by browserify
     const moduleName = 'aws-sdk';
@@ -140,37 +138,11 @@ const zfactory = zcli => {
   };
 
   const dehydrateFile = (url, requestOptions, meta) => {
-    url = url || undefined;
-    requestOptions = requestOptions || undefined;
-    meta = meta || undefined;
-
-    if (!url && !request) {
-      throw new exceptions.DehydrateException(
-        'You must provide either url or request arguments!'
-      );
-    }
-
-    if (url && typeof url !== 'string') {
-      throw new exceptions.DehydrateException(
-        'The provided url is not a string!'
-      );
-    }
-
-    return (
-      'hydrate|||' +
-      JSON.stringify({
-        type: 'method',
-        method: 'hydrators._legacyHydrateFile',
-
-        // will be available as bundle.inputData actually
-        bundle: {
-          url,
-          request: requestOptions,
-          meta
-        }
-      }) +
-      '|||hydrate'
-    );
+    return zcli.dehydrateFile(app.hydrators.legacyFileHydrator, {
+      url,
+      request: requestOptions,
+      meta
+    });
   };
 
   return {


### PR DESCRIPTION
Implements `z.dehydrateFile` conversion. There's some code auto-formatting noise in PR, but this is how it's going to work:

* WB scripting `z.dehydrateFile(url, request, meta)` is converted to CLI `z.dehydrateFile(hydrators.legacyFileHydrator, { url, request, meta })`.
* Every converted app will have a `hydrators.legacyFileHydrator` in their app definition. The work is done in https://github.com/zapier/zapier/pull/19418.
* `hydrators.legacyFileHydrator` calls `z.legacyScripting.run(bundle, 'hydrate.file')`, which calls into `runHydrateFile` in this PR.
* `runHydrateFile` does typical CLI file hydration that involves `z.stashFile`. It also simulates WB behavior where we don't send auth data when `request` argument isn't provided in `z.dehydrateFile`. This PR has tests to confirm that.

Some requirements of this PR:

* Requires `z.dehydrateFile` to be available in `core`. The current one on npm (7.2.2) doesn't have it yet, so the tests are expected to fail on Travis. To run tests locally, you need to run it against the latest development version of `core`.
* (BREAKING CHANGE) `legacyScriptingRunner` now takes `(Zap, zcli, input)` instead of `(Zap, zcli, app)`. This requires https://github.com/zapier/zapier-platform-core/pull/122. It's more flexible to have access to `input` here in this package. In this case, we use it create an internal request client that only runs default middlewares, excluding `beforeRequest` and `afterResponse` middlewares.