### PR TITLE
Convert z.dehydrate

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -92,6 +92,8 @@ const addInputData = (event, bundle, convertedBundle) => {
       convertedBundle.read_fields = event.results || bundle.inputData;
       convertedBundle.read_context = bundle.inputData;
     }
+  } else if (event.name === 'hydrate.method') {
+    _.extend(convertedBundle, bundle.inputData.bundle);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -289,7 +289,12 @@ const createEventNameToMethodMapping = key => {
     'search.input.post': `${key}_post_custom_search_fields`,
     'search.output': `${key}_custom_search_result_fields`,
     'search.output.pre': `${key}_pre_custom_search_result_fields`,
-    'search.output.post': `${key}_post_custom_search_result_fields`
+    'search.output.post': `${key}_post_custom_search_result_fields`,
+
+    //
+    // Hydration
+    //
+    'hydrate.method': key
   };
 };
 
@@ -765,6 +770,11 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     return runCustomFields(bundle, key, 'search.output', url);
   };
 
+  const runHydrateMethod = bundle => {
+    const methodName = bundle.inputData.method;
+    return runEvent({ name: 'hydrate.method', key: methodName }, zcli, bundle);
+  };
+
   const runHydrateFile = bundle => {
     const meta = bundle.inputData.meta || {};
     const requestOptions = bundle.inputData.request || {};
@@ -834,6 +844,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
           return runSearchInputFields(bundle, key);
         case 'search.output':
           return runSearchOutputFields(bundle, key);
+        case 'hydrate.method':
+          return runHydrateMethod(bundle);
         case 'hydrate.file':
           return runHydrateFile(bundle);
       }

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1519,11 +1519,11 @@ describe('Integration Test', () => {
     });
 
     describe('legacyMethodHydrator', () => {
-      it('should get data if auth is correct', () => {
-        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
-        const app = createApp(appDefWithAuth);
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
 
+      it('should get data if auth is correct', () => {
         const input = createTestInput(
           compiledApp,
           'hydrators.legacyMethodHydrator'
@@ -1543,10 +1543,6 @@ describe('Integration Test', () => {
       });
 
       it('should fail if bad auth', () => {
-        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
-        const app = createApp(appDefWithAuth);
-
         const input = createTestInput(
           compiledApp,
           'hydrators.legacyMethodHydrator'
@@ -1562,10 +1558,6 @@ describe('Integration Test', () => {
       });
 
       it('should fail if no auth', () => {
-        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
-        const app = createApp(appDefWithAuth);
-
         const input = createTestInput(
           compiledApp,
           'hydrators.legacyMethodHydrator'

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -336,6 +336,37 @@ describe('Integration Test', () => {
       });
     });
 
+    it('z.dehydrate', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+        'movie_post_poll_method_dehydration',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then(output => {
+        const movies = output.results;
+        movies.length.should.greaterThan(1);
+        movies.forEach(movie => {
+          movie.user.should.startWith('hydrate|||');
+          movie.user.should.endWith('|||hydrate');
+
+          const payload = JSON.parse(movie.user.split('|||')[1]);
+          should.equal(payload.type, 'method');
+          should.equal(payload.method, 'hydrators.legacyMethodHydrator');
+          should.equal(payload.bundle.method, 'getUser');
+          should.equal(payload.bundle.bundle.userId, movie.id);
+        });
+      });
+    });
+
     it('z.dehydrateFile', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
@@ -1484,6 +1515,68 @@ describe('Integration Test', () => {
 
         const data = JSON.parse(output.results.data);
         should.equal(data.filename, 'dont.care');
+      });
+    });
+
+    describe('legacyMethodHydrator', () => {
+      it('should get data if auth is correct', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createApp(appDefWithAuth);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyMethodHydrator'
+        );
+        input.bundle.authData = { api_key: 'secret' };
+        input.bundle.inputData = {
+          method: 'getUser',
+          bundle: {
+            userId: 3
+          }
+        };
+        return app(input).then(output => {
+          const user = output.results;
+          should.equal(user.id, 3);
+          should.equal(user.name, 'Clementine Bauch');
+        });
+      });
+
+      it('should fail if bad auth', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createApp(appDefWithAuth);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyMethodHydrator'
+        );
+        input.bundle.authData = { api_key: 'bad key' };
+        input.bundle.inputData = {
+          method: 'getUser',
+          bundle: {
+            userId: 3
+          }
+        };
+        return app(input).should.be.rejectedWith(/Unauthorized/);
+      });
+
+      it('should fail if no auth', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createApp(appDefWithAuth);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyMethodHydrator'
+        );
+        input.bundle.inputData = {
+          method: 'getUser',
+          bundle: {
+            userId: 3
+          }
+        };
+        return app(input).should.be.rejectedWith(/Unauthorized/);
       });
     });
 

--- a/zfactory.js
+++ b/zfactory.js
@@ -137,6 +137,13 @@ const zfactory = (zcli, app) => {
     return `:censored:${length}:${result.substr(0, 10)}:`;
   };
 
+  const dehydrate = (method, bundle) => {
+    return zcli.dehydrate(app.hydrators.legacyMethodHydrator, {
+      method,
+      bundle
+    });
+  };
+
   const dehydrateFile = (url, requestOptions, meta) => {
     return zcli.dehydrateFile(app.hydrators.legacyFileHydrator, {
       url,
@@ -155,6 +162,7 @@ const zfactory = (zcli, app) => {
     hash,
     hmac,
     snipify,
+    dehydrate,
     dehydrateFile
   };
 };


### PR DESCRIPTION
Implements the conversion for `z.dehydrate`. This works a lot like `z.dehydrateFile` conversion (#24). That is:

* All converted apps will have a hydrator named `hydrators.legacyMethodHydrator` that simply returns `z.legacyScripting.run(bundle, 'hydrate.method')`. This is done in https://github.com/zapier/zapier/pull/20722.
* Legacy WB scripting's `z.dehydrate(methodName, legacyBundle)` is translated to CLI's `z.dehydrate(hydrators.legacyMethodHydrator, { method: methodName, bundle: legacyBundle })`.
* `z.legacyScripting.run(bundle, 'hydrate.method')` calls `runHydrateMethod`, which then calls the actual hydrator in the legacy scripting, such as `Zap.get_user`.

This PR depends on the latest work in core that hasn't been published to npm. It's expected to fail on Travis. We can only run tests locally against the latest development version of core.