### PR TITLE
Re-org legacy props

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,7 +499,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth1GetRequestToken = async bundle => {
-    const url = _.get(app, 'legacy.authentication.requestTokenUrl');
+    const url = _.get(app, 'legacy.authentication.oauth1Config.requestTokenUrl');
     return await fetchOAuth1Token(url, {
       oauth_consumer_key: process.env.CLIENT_ID,
       oauth_consumer_secret: process.env.CLIENT_SECRET,
@@ -509,7 +509,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth1GetAccessToken = async bundle => {
-    const url = _.get(app, 'legacy.authentication.accessTokenUrl');
+    const url = _.get(app, 'legacy.authentication.oauth1Config.accessTokenUrl');
     return await fetchOAuth1Token(url, {
       oauth_consumer_key: process.env.CLIENT_ID,
       oauth_consumer_secret: process.env.CLIENT_SECRET,
@@ -520,7 +520,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth2GetAccessToken = bundle => {
-    const url = _.get(app, 'legacy.authentication.accessTokenUrl');
+    const url = _.get(app, 'legacy.authentication.oauth2Config.accessTokenUrl');
 
     const request = bundle.request;
     request.method = 'POST';
@@ -543,7 +543,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth2RefreshAccessToken = bundle => {
-    const url = _.get(app, 'legacy.authentication.refreshTokenUrl');
+    const url = _.get(app, 'legacy.authentication.oauth2Config.refreshTokenUrl');
 
     const request = bundle.request;
     request.method = 'POST';
@@ -560,7 +560,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runTrigger = (bundle, key) => {
-    const url = _.get(app, `legacy.triggers.${key}.url`);
+    const url = _.get(app, `legacy.triggers.${key}.operation.url`);
     bundle.request.url = url;
 
     // For auth test we want to make sure we return an object instead of an array
@@ -596,7 +596,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runHook = (bundle, key) => {
-    const hookType = _.get(app, `legacy.triggers.${key}.hookType`);
+    const hookType = _.get(app, `legacy.triggers.${key}.operation.hookType`);
 
     let cleanedArray;
     if (Array.isArray(bundle.cleanedRequest)) {
@@ -627,7 +627,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
   const runHookSubscribe = (bundle, key) => {
     const url = _.get(app, 'legacy.subscribeUrl');
-    const event = _.get(app, `legacy.triggers.${key}.event`);
+    const event = _.get(app, `legacy.triggers.${key}.operation.event`);
 
     const request = bundle.request;
     request.method = 'POST';
@@ -648,7 +648,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
   const runHookUnsubscribe = (bundle, key) => {
     const url = _.get(app, 'legacy.unsubscribeUrl');
-    const event = _.get(app, `legacy.triggers.${key}.event`);
+    const event = _.get(app, `legacy.triggers.${key}.operation.event`);
 
     const request = bundle.request;
     request.method = 'POST';
@@ -700,12 +700,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runTriggerOutputFields = (bundle, key) => {
-    const url = _.get(app, `legacy.triggers.${key}.outputFieldsUrl`);
+    const url = _.get(app, `legacy.triggers.${key}.operation.outputFieldsUrl`);
     return runCustomFields(bundle, key, 'trigger.output', url, false);
   };
 
   const runCreate = (bundle, key) => {
-    const legacyProps = _.get(app, `legacy.creates.${key}`) || {};
+    const legacyProps = _.get(app, `legacy.creates.${key}.operation`) || {};
     const url = legacyProps.url;
     const fieldsExcludedFromBody = legacyProps.fieldsExcludedFromBody || [];
 
@@ -735,17 +735,17 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runCreateInputFields = (bundle, key) => {
-    const url = _.get(app, `legacy.creates.${key}.inputFieldsUrl`);
+    const url = _.get(app, `legacy.creates.${key}.operation.inputFieldsUrl`);
     return runCustomFields(bundle, key, 'create.input', url);
   };
 
   const runCreateOutputFields = (bundle, key) => {
-    const url = _.get(app, `legacy.creates.${key}.outputFieldsUrl`);
+    const url = _.get(app, `legacy.creates.${key}.operation.outputFieldsUrl`);
     return runCustomFields(bundle, key, 'create.output', url);
   };
 
   const runSearch = (bundle, key) => {
-    const url = _.get(app, `legacy.searches.${key}.url`);
+    const url = _.get(app, `legacy.searches.${key}.operation.url`);
 
     bundle.request.url = url;
 
@@ -760,7 +760,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runSearchResource = (bundle, key) => {
-    const url = _.get(app, `legacy.searches.${key}.resourceUrl`);
+    const url = _.get(app, `legacy.searches.${key}.operation.resourceUrl`);
     bundle.request.url = url;
 
     return runEventCombo(
@@ -774,12 +774,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runSearchInputFields = (bundle, key) => {
-    const url = _.get(app, `legacy.searches.${key}.inputFieldsUrl`);
+    const url = _.get(app, `legacy.searches.${key}.operation.inputFieldsUrl`);
     return runCustomFields(bundle, key, 'search.input', url);
   };
 
   const runSearchOutputFields = (bundle, key) => {
-    const url = _.get(app, `legacy.searches.${key}.outputFieldsUrl`);
+    const url = _.get(app, `legacy.searches.${key}.operation.outputFieldsUrl`);
     return runCustomFields(bundle, key, 'search.output', url);
   };
 

--- a/index.js
+++ b/index.js
@@ -499,10 +499,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth1GetRequestToken = async bundle => {
-    const url = _.get(
-      app,
-      'authentication.oauth1Config.legacyProperties.requestTokenUrl'
-    );
+    const url = _.get(app, 'legacy.authentication.requestTokenUrl');
     return await fetchOAuth1Token(url, {
       oauth_consumer_key: process.env.CLIENT_ID,
       oauth_consumer_secret: process.env.CLIENT_SECRET,
@@ -512,10 +509,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth1GetAccessToken = async bundle => {
-    const url = _.get(
-      app,
-      'authentication.oauth1Config.legacyProperties.accessTokenUrl'
-    );
+    const url = _.get(app, 'legacy.authentication.accessTokenUrl');
     return await fetchOAuth1Token(url, {
       oauth_consumer_key: process.env.CLIENT_ID,
       oauth_consumer_secret: process.env.CLIENT_SECRET,
@@ -526,10 +520,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth2GetAccessToken = bundle => {
-    const url = _.get(
-      app,
-      'authentication.oauth2Config.legacyProperties.accessTokenUrl'
-    );
+    const url = _.get(app, 'legacy.authentication.accessTokenUrl');
 
     const request = bundle.request;
     request.method = 'POST';
@@ -552,10 +543,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth2RefreshAccessToken = bundle => {
-    const url = _.get(
-      app,
-      'authentication.oauth2Config.legacyProperties.refreshTokenUrl'
-    );
+    const url = _.get(app, 'legacy.authentication.refreshTokenUrl');
 
     const request = bundle.request;
     request.method = 'POST';
@@ -572,7 +560,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runTrigger = (bundle, key) => {
-    const url = _.get(app, `triggers.${key}.operation.legacyProperties.url`);
+    const url = _.get(app, `legacy.triggers.${key}.url`);
     bundle.request.url = url;
 
     // For auth test we want to make sure we return an object instead of an array
@@ -608,10 +596,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runHook = (bundle, key) => {
-    const hookType = _.get(
-      app,
-      `triggers.${key}.operation.legacyProperties.hookType`
-    );
+    const hookType = _.get(app, `legacy.triggers.${key}.hookType`);
 
     let cleanedArray;
     if (Array.isArray(bundle.cleanedRequest)) {
@@ -641,11 +626,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runHookSubscribe = (bundle, key) => {
-    const url = _.get(app, 'legacyProperties.subscribeUrl');
-    const event = _.get(
-      app,
-      `triggers.${key}.operation.legacyProperties.event`
-    );
+    const url = _.get(app, 'legacy.subscribeUrl');
+    const event = _.get(app, `legacy.triggers.${key}.event`);
 
     const request = bundle.request;
     request.method = 'POST';
@@ -665,11 +647,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runHookUnsubscribe = (bundle, key) => {
-    const url = _.get(app, 'legacyProperties.unsubscribeUrl');
-    const event = _.get(
-      app,
-      `triggers.${key}.operation.legacyProperties.event`
-    );
+    const url = _.get(app, 'legacy.unsubscribeUrl');
+    const event = _.get(app, `legacy.triggers.${key}.event`);
 
     const request = bundle.request;
     request.method = 'POST';
@@ -721,16 +700,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runTriggerOutputFields = (bundle, key) => {
-    const url = _.get(
-      app,
-      `triggers.${key}.operation.legacyProperties.outputFieldsUrl`
-    );
+    const url = _.get(app, `legacy.triggers.${key}.outputFieldsUrl`);
     return runCustomFields(bundle, key, 'trigger.output', url, false);
   };
 
   const runCreate = (bundle, key) => {
-    const legacyProps =
-      _.get(app, `creates.${key}.operation.legacyProperties`) || {};
+    const legacyProps = _.get(app, `legacy.creates.${key}`) || {};
     const url = legacyProps.url;
     const fieldsExcludedFromBody = legacyProps.fieldsExcludedFromBody || [];
 
@@ -760,23 +735,17 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runCreateInputFields = (bundle, key) => {
-    const url = _.get(
-      app,
-      `creates.${key}.operation.legacyProperties.inputFieldsUrl`
-    );
+    const url = _.get(app, `legacy.creates.${key}.inputFieldsUrl`);
     return runCustomFields(bundle, key, 'create.input', url);
   };
 
   const runCreateOutputFields = (bundle, key) => {
-    const url = _.get(
-      app,
-      `creates.${key}.operation.legacyProperties.outputFieldsUrl`
-    );
+    const url = _.get(app, `legacy.creates.${key}.outputFieldsUrl`);
     return runCustomFields(bundle, key, 'create.output', url);
   };
 
   const runSearch = (bundle, key) => {
-    const url = _.get(app, `searches.${key}.operation.legacyProperties.url`);
+    const url = _.get(app, `legacy.searches.${key}.url`);
 
     bundle.request.url = url;
 
@@ -791,10 +760,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runSearchResource = (bundle, key) => {
-    const url = _.get(
-      app,
-      `searches.${key}.operation.legacyProperties.resourceUrl`
-    );
+    const url = _.get(app, `legacy.searches.${key}.resourceUrl`);
     bundle.request.url = url;
 
     return runEventCombo(
@@ -808,18 +774,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runSearchInputFields = (bundle, key) => {
-    const url = _.get(
-      app,
-      `searches.${key}.operation.legacyProperties.inputFieldsUrl`
-    );
+    const url = _.get(app, `legacy.searches.${key}.inputFieldsUrl`);
     return runCustomFields(bundle, key, 'search.input', url);
   };
 
   const runSearchOutputFields = (bundle, key) => {
-    const url = _.get(
-      app,
-      `searches.${key}.operation.legacyProperties.outputFieldsUrl`
-    );
+    const url = _.get(app, `legacy.searches.${key}.outputFieldsUrl`);
     return runCustomFields(bundle, key, 'search.output', url);
   };
 

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -724,63 +724,80 @@ const App = {
   },
   legacy: {
     scriptingSource: legacyScriptingSource,
+
     subscribeUrl: 'http://zapier-httpbin.herokuapp.com/post',
     unsubscribeUrl: 'https://zapier-httpbin.herokuapp.com/delete',
 
     authentication: {
-      // OAuth2
-      // Incomplete URLs on purpose to test pre_oauthv2_token
-      accessTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/access-`,
-      refreshTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/refresh-`
-
+      oauth2Config: {
+        // Incomplete URLs on purpose to test pre_oauthv2_token
+        accessTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/access-`,
+        refreshTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/refresh-`
+      }
     },
 
     triggers: {
       contact_full: {
-        // The URL misses an 's' at the end of the resource names. That is,
-        // 'output-field' where it should be 'output-fields'. Done purposely for
-        // scripting to fix it.
-        outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
+        operation: {
+          // The URL misses an 's' at the end of the resource names. That is,
+          // 'output-field' where it should be 'output-fields'. Done purposely for
+          // scripting to fix it.
+          outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
+        }
       },
       contact_post: {
-        url: `${AUTH_JSON_SERVER_URL}/users`
+        operation: {
+          url: `${AUTH_JSON_SERVER_URL}/users`
+        }
       },
       contact_hook_scripting: {
-        event: 'contact.created',
-        hookType: 'rest'
+        operation: {
+          event: 'contact.created',
+          hookType: 'rest'
+        }
       },
       test: {
-        url: `${AUTH_JSON_SERVER_URL}/me`
+        operation: {
+          url: `${AUTH_JSON_SERVER_URL}/me`
+        }
       },
       movie: {
-        url: `${AUTH_JSON_SERVER_URL}/movies`
+        operation: {
+          url: `${AUTH_JSON_SERVER_URL}/movies`
+        }
       }
     },
 
     creates: {
       movie: {
-        // These URLs miss an 's' at the end of the resource names. That is,
-        // 'movie' where it should be 'movies' and 'input-field' where it should
-        // be 'input-fields'. Done purposely for scripting to fix it.
-        url: `${AUTH_JSON_SERVER_URL}/movie`,
-        inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
-        outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`,
-        fieldsExcludedFromBody: ['title']
+        operation: {
+          // These URLs miss an 's' at the end of the resource names. That is,
+          // 'movie' where it should be 'movies' and 'input-field' where it should
+          // be 'input-fields'. Done purposely for scripting to fix it.
+          url: `${AUTH_JSON_SERVER_URL}/movie`,
+          inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
+          outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`,
+          fieldsExcludedFromBody: ['title']
+        }
       },
       file: {
-        url: `${AUTH_JSON_SERVER_URL}/upload`
+        operation: {
+          url: `${AUTH_JSON_SERVER_URL}/upload`
+        }
       }
     },
 
     searches: {
       movie: {
-        // These URLs miss an 's' at the end of the resource names. That is,
-        // 'movie' where it should be 'movies' and 'input-field' where it should
-        // be 'input-fields'. Done purposely for scripting to fix it.
-        url: `${AUTH_JSON_SERVER_URL}/movie?q={{bundle.inputData.query}}`,
-        resourceUrl: `${AUTH_JSON_SERVER_URL}/movie/{{bundle.inputData.id}}`,
-        inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
-        outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
+        operation: {
+          // These URLs miss an 's' at the end of the resource names. That is,
+          // 'movie' where it should be 'movies' and 'input-field' where it should
+          // be 'input-fields'. Done purposely for scripting to fix it.
+          url: `${AUTH_JSON_SERVER_URL}/movie?q={{bundle.inputData.query}}`,
+          resourceUrl: `${AUTH_JSON_SERVER_URL}/movie/{{bundle.inputData.id}}`,
+          inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
+          outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
+        }
       }
     }
   }

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -512,13 +512,7 @@ const ContactTrigger_full = {
         source:
           "return z.legacyScripting.run(bundle, 'trigger.output', 'contact_full');"
       }
-    ],
-    legacyProperties: {
-      // The URL misses an 's' at the end of the resource names. That is,
-      // 'output-field' where it should be 'output-fields'. Done purposely for
-      // scripting to fix it.
-      outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
-    }
+    ]
   }
 };
 
@@ -542,9 +536,6 @@ const ContactTrigger_post = {
     label: 'New Contact with Post Scripting'
   },
   operation: {
-    legacyProperties: {
-      url: `${AUTH_JSON_SERVER_URL}/users`
-    },
     perform: {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'contact_post');"
     }
@@ -597,10 +588,6 @@ const ContactHook_scripting = {
     performUnsubscribe: {
       source:
         "return z.legacyScripting.run(bundle, 'trigger.hook.unsubscribe', 'contact_hook_scripting');"
-    },
-    legacyProperties: {
-      event: 'contact.created',
-      hookType: 'rest'
     }
   }
 };
@@ -613,9 +600,6 @@ const TestTrigger = {
   operation: {
     perform: {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'test');"
-    },
-    legacyProperties: {
-      url: `${AUTH_JSON_SERVER_URL}/me`
     }
   }
 };
@@ -628,9 +612,6 @@ const MovieTrigger = {
   operation: {
     perform: {
       source: "return z.legacyScripting.run(bundle, 'trigger', 'movie');"
-    },
-    legacyProperties: {
-      url: `${AUTH_JSON_SERVER_URL}/movies`
     }
   }
 };
@@ -660,16 +641,7 @@ const MovieCreate = {
         source:
           "return z.legacyScripting.run(bundle, 'create.output', 'movie');"
       }
-    ],
-    legacyProperties: {
-      // These URLs miss an 's' at the end of the resource names. That is,
-      // 'movie' where it should be 'movies' and 'input-field' where it should
-      // be 'input-fields'. Done purposely for scripting to fix it.
-      url: `${AUTH_JSON_SERVER_URL}/movie`,
-      inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
-      outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`,
-      fieldsExcludedFromBody: ['title']
-    }
+    ]
   }
 };
 
@@ -687,10 +659,7 @@ const FileUpload = {
       { key: 'filename', label: 'Filename', type: 'string' },
       { key: 'file', label: 'File', type: 'file' }
     ],
-    outputFields: [{ key: 'id', label: 'ID', type: 'integer' }],
-    legacyProperties: {
-      url: `${AUTH_JSON_SERVER_URL}/upload`
-    }
+    outputFields: [{ key: 'id', label: 'ID', type: 'integer' }]
   }
 };
 
@@ -722,16 +691,7 @@ const MovieSearch = {
         source:
           "return z.legacyScripting.run(bundle, 'search.output', 'movie');"
       }
-    ],
-    legacyProperties: {
-      // These URLs miss an 's' at the end of the resource names. That is,
-      // 'movie' where it should be 'movies' and 'input-field' where it should
-      // be 'input-fields'. Done purposely for scripting to fix it.
-      url: `${AUTH_JSON_SERVER_URL}/movie?q={{bundle.inputData.query}}`,
-      resourceUrl: `${AUTH_JSON_SERVER_URL}/movie/{{bundle.inputData.id}}`,
-      inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
-      outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
-    }
+    ]
   }
 };
 
@@ -762,11 +722,68 @@ const App = {
       source: "return z.legacyScripting.run(bundle, 'hydrate.file');"
     }
   },
-  legacyProperties: {
+  legacy: {
+    scriptingSource: legacyScriptingSource,
     subscribeUrl: 'http://zapier-httpbin.herokuapp.com/post',
-    unsubscribeUrl: 'https://zapier-httpbin.herokuapp.com/delete'
-  },
-  legacyScriptingSource
+    unsubscribeUrl: 'https://zapier-httpbin.herokuapp.com/delete',
+
+    authentication: {
+      // OAuth2
+      // Incomplete URLs on purpose to test pre_oauthv2_token
+      accessTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/access-`,
+      refreshTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/refresh-`
+
+    },
+
+    triggers: {
+      contact_full: {
+        // The URL misses an 's' at the end of the resource names. That is,
+        // 'output-field' where it should be 'output-fields'. Done purposely for
+        // scripting to fix it.
+        outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
+      },
+      contact_post: {
+        url: `${AUTH_JSON_SERVER_URL}/users`
+      },
+      contact_hook_scripting: {
+        event: 'contact.created',
+        hookType: 'rest'
+      },
+      test: {
+        url: `${AUTH_JSON_SERVER_URL}/me`
+      },
+      movie: {
+        url: `${AUTH_JSON_SERVER_URL}/movies`
+      }
+    },
+
+    creates: {
+      movie: {
+        // These URLs miss an 's' at the end of the resource names. That is,
+        // 'movie' where it should be 'movies' and 'input-field' where it should
+        // be 'input-fields'. Done purposely for scripting to fix it.
+        url: `${AUTH_JSON_SERVER_URL}/movie`,
+        inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
+        outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`,
+        fieldsExcludedFromBody: ['title']
+      },
+      file: {
+        url: `${AUTH_JSON_SERVER_URL}/upload`
+      }
+    },
+
+    searches: {
+      movie: {
+        // These URLs miss an 's' at the end of the resource names. That is,
+        // 'movie' where it should be 'movies' and 'input-field' where it should
+        // be 'input-fields'. Done purposely for scripting to fix it.
+        url: `${AUTH_JSON_SERVER_URL}/movie?q={{bundle.inputData.query}}`,
+        resourceUrl: `${AUTH_JSON_SERVER_URL}/movie/{{bundle.inputData.id}}`,
+        inputFieldsUrl: `${AUTH_JSON_SERVER_URL}/input-field`,
+        outputFieldsUrl: `${AUTH_JSON_SERVER_URL}/output-field`
+      }
+    }
+  }
 };
 
 module.exports = App;

--- a/test/example-app/oauth2.js
+++ b/test/example-app/oauth2.js
@@ -42,11 +42,6 @@ module.exports = {
       }
     ],
     oauth2Config: {
-      legacyProperties: {
-        // Incomplete URLs on purpose to test pre_oauthv2_token
-        accessTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/access-`,
-        refreshTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/refresh-`
-      },
       authorizeUrl: {
         method: 'GET',
         url: `${AUTH_JSON_SERVER_URL}/oauth/authorize`,

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -83,10 +83,7 @@ describe('Integration Test', () => {
     });
 
     it('authentication.test', () => {
-      const input = createTestInput(
-        compiledApp,
-        'authentication.test'
-      );
+      const input = createTestInput(compiledApp, 'authentication.test');
       input.bundle.authData = {
         key1: 'sec',
         key2: 'ret'
@@ -117,7 +114,7 @@ describe('Integration Test', () => {
 
     it('pre_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'post_oauthv2_token',
         'dont_care'
       );
@@ -141,12 +138,11 @@ describe('Integration Test', () => {
 
     it('post_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'pre_oauthv2_token',
         'dont_care'
       );
-      appDefWithAuth.authentication.oauth2Config.legacyProperties.accessTokenUrl +=
-        'token';
+      appDefWithAuth.legacy.authentication.accessTokenUrl += 'token';
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
 
@@ -267,7 +263,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_trigger_fields', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_full_post_custom_trigger_fields',
         'contact_full_post_custom_trigger_fields_disabled'
       );
@@ -293,9 +289,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_trigger_fields', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.triggers.contact_full.operation.legacyProperties.outputFieldsUrl +=
-        's';
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.triggers.contact_full.outputFieldsUrl += 's';
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_full_pre_custom_trigger_fields',
         'contact_full_pre_custom_trigger_fields_disabled'
       );
@@ -340,7 +335,7 @@ describe('Integration Test', () => {
 
     it('z.dehydrate', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'movie_post_poll_method_dehydration',
         'movie_post_poll'
       );
@@ -371,7 +366,7 @@ describe('Integration Test', () => {
 
     it('z.dehydrateFile', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'movie_post_poll_file_dehydration',
         'movie_post_poll'
       );
@@ -429,7 +424,7 @@ describe('Integration Test', () => {
 
     it('KEY_catch_hook => object', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_catch_hook_returning_object',
         'contact_hook_scripting_catch_hook'
       );
@@ -454,7 +449,7 @@ describe('Integration Test', () => {
 
     it('KEY_catch_hook => array', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_catch_hook_returning_array',
         'contact_hook_scripting_catch_hook'
       );
@@ -482,11 +477,11 @@ describe('Integration Test', () => {
     it('REST Hook should ignore KEY_pre_hook', () => {
       // Not a Notication REST hook, KEY_pre_hook should be ignored
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_catch_hook_returning_object',
         'contact_hook_scripting_catch_hook'
       );
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_pre_hook_disabled',
         'contact_hook_scripting_pre_hook'
       );
@@ -518,13 +513,12 @@ describe('Integration Test', () => {
       // Notication REST hook should fall back what REST Hook does when the
       // hook doesn't have resource_url
       const appDef = _.cloneDeep(appDefinition);
-      appDef.triggers.contact_hook_scripting.operation.legacyProperties.hookType =
-        'notification';
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_catch_hook_returning_object',
         'contact_hook_scripting_catch_hook'
       );
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_pre_hook_disabled',
         'contact_hook_scripting_pre_hook'
       );
@@ -553,9 +547,8 @@ describe('Integration Test', () => {
 
     it('KEY_pre_hook', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.triggers.contact_hook_scripting.operation.legacyProperties.hookType =
-        'notification';
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_pre_hook_disabled',
         'contact_hook_scripting_pre_hook'
       );
@@ -584,9 +577,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_hook => object', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.triggers.contact_hook_scripting.operation.legacyProperties.hookType =
-        'notification';
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_post_hook_returning_object',
         'contact_hook_scripting_post_hook'
       );
@@ -616,9 +608,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_hook => array', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.triggers.contact_hook_scripting.operation.legacyProperties.hookType =
-        'notification';
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_post_hook_returning_array',
         'contact_hook_scripting_post_hook'
       );
@@ -650,13 +641,12 @@ describe('Integration Test', () => {
 
     it('KEY_pre_hook & KEY_post_hook => object', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.triggers.contact_hook_scripting.operation.legacyProperties.hookType =
-        'notification';
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_pre_hook_disabled',
         'contact_hook_scripting_pre_hook'
       );
-      appDef.legacyScriptingSource = appDef.legacyScriptingSource.replace(
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_post_hook_returning_object',
         'contact_hook_scripting_post_hook'
       );
@@ -729,7 +719,7 @@ describe('Integration Test', () => {
   describe('create', () => {
     it('scriptingless perform', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.creates.movie.operation.legacyProperties.url += 's';
+      appDefWithAuth.legacy.creates.movie.url += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -753,8 +743,7 @@ describe('Integration Test', () => {
 
     it('scriptingless perform, curlies in URL', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps =
-        appDefWithAuth.creates.movie.operation.legacyProperties;
+      const legacyProps = appDefWithAuth.legacy.creates.movie;
       legacyProps.url = legacyProps.url.replace(
         '/movie',
         '/{{bundle.inputData.resource_name}}'
@@ -783,7 +772,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_write_disabled',
         'movie_pre_write'
       );
@@ -810,8 +799,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.creates.movie.operation.legacyProperties.url += 's';
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.creates.movie.url += 's';
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_write_disabled',
         'movie_post_write'
       );
@@ -839,11 +828,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_write & KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_write_disabled',
         'movie_pre_write'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_write_disabled',
         'movie_post_write'
       );
@@ -871,7 +860,7 @@ describe('Integration Test', () => {
 
     it('async KEY_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_write_async',
         'movie_write'
       );
@@ -899,7 +888,7 @@ describe('Integration Test', () => {
 
     it('sync KEY_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_write_sync',
         'movie_write'
       );
@@ -927,12 +916,11 @@ describe('Integration Test', () => {
 
     it('sync KEY_write, curlies in URL', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_write_sync',
         'movie_write'
       );
-      const legacyProps =
-        appDefWithAuth.creates.movie.operation.legacyProperties;
+      const legacyProps = appDefWithAuth.legacy.creates.movie;
       legacyProps.url = legacyProps.url.replace(
         '/movie',
         '/{{bundle.inputData.resource_name}}'
@@ -962,8 +950,7 @@ describe('Integration Test', () => {
 
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.creates.movie.operation.legacyProperties.inputFieldsUrl +=
-        's';
+      appDefWithAuth.legacy.creates.movie.inputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -984,7 +971,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_action_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_action_fields_disabled',
         'movie_pre_custom_action_fields'
       );
@@ -1008,9 +995,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_action_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.creates.movie.operation.legacyProperties.inputFieldsUrl +=
-        's';
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.creates.movie.inputFieldsUrl += 's';
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_action_fields_disabled',
         'movie_post_custom_action_fields'
       );
@@ -1036,11 +1022,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_action_fields & KEY_post_custom_action_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_action_fields_disabled',
         'movie_pre_custom_action_fields'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_action_fields_disabled',
         'movie_post_custom_action_fields'
       );
@@ -1066,7 +1052,7 @@ describe('Integration Test', () => {
 
     it('KEY_custom_action_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_custom_action_fields_disabled',
         'movie_custom_action_fields'
       );
@@ -1092,8 +1078,7 @@ describe('Integration Test', () => {
 
     it('scriptingless output fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.creates.movie.operation.legacyProperties.outputFieldsUrl +=
-        's';
+      appDefWithAuth.legacy.creates.movie.outputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -1117,7 +1102,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_action_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_action_result_fields_disabled',
         'movie_pre_custom_action_result_fields'
       );
@@ -1144,9 +1129,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_action_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.creates.movie.operation.legacyProperties.outputFieldsUrl +=
-        's';
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.creates.movie.outputFieldsUrl += 's';
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_action_result_fields_disabled',
         'movie_post_custom_action_result_fields'
       );
@@ -1175,11 +1159,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_action_result_fields & KEY_post_custom_action_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_action_result_fields_disabled',
         'movie_pre_custom_action_result_fields'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_action_result_fields_disabled',
         'movie_post_custom_action_result_fields'
       );
@@ -1208,7 +1192,7 @@ describe('Integration Test', () => {
 
     it('KEY_custom_action_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_custom_action_result_fields_disabled',
         'movie_custom_action_result_fields'
       );
@@ -1290,7 +1274,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write tweaks filename', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_tweak_filename',
         'file_pre_write'
       );
@@ -1319,7 +1303,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write replaces hydrate url', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_replace_hydrate_url',
         'file_pre_write'
       );
@@ -1348,7 +1332,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write replaces with string content', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_replace_with_string_content',
         'file_pre_write'
       );
@@ -1377,7 +1361,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write fully replaces URL', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_fully_replace_url',
         'file_pre_write'
       );
@@ -1406,7 +1390,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write fully replaces content', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_fully_replace_content',
         'file_pre_write'
       );
@@ -1435,7 +1419,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write, content disposition with quotes', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_content_dispoistion_with_quotes',
         'file_pre_write'
       );
@@ -1464,7 +1448,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write, content disposition without quotes', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_content_dispoistion_no_quotes',
         'file_pre_write'
       );
@@ -1493,7 +1477,7 @@ describe('Integration Test', () => {
 
     it('file upload, KEY_pre_write, content disposition non-ascii', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'file_pre_write_content_dispoistion_non_ascii',
         'file_pre_write'
       );
@@ -1724,8 +1708,7 @@ describe('Integration Test', () => {
   describe('search', () => {
     it('scriptingless perform', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps =
-        appDefWithAuth.searches.movie.operation.legacyProperties;
+      const legacyProps = appDefWithAuth.legacy.searches.movie;
       legacyProps.url = legacyProps.url.replace('movie?', 'movies?');
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -1749,7 +1732,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_search', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_search_disabled',
         'movie_pre_search'
       );
@@ -1775,10 +1758,9 @@ describe('Integration Test', () => {
 
     it('KEY_post_search', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps =
-        appDefWithAuth.searches.movie.operation.legacyProperties;
+      const legacyProps = appDefWithAuth.legacy.searches.movie;
       legacyProps.url = legacyProps.url.replace('movie?', 'movies?');
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_search_disabled',
         'movie_post_search'
       );
@@ -1804,11 +1786,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_search & KEY_post_search', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_search_disabled',
         'movie_pre_search'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_search_disabled',
         'movie_post_search'
       );
@@ -1834,7 +1816,7 @@ describe('Integration Test', () => {
 
     it('KEY_search', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_search_disabled',
         'movie_search'
       );
@@ -1860,8 +1842,7 @@ describe('Integration Test', () => {
 
     it('scriptingless resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps =
-        appDefWithAuth.searches.movie.operation.legacyProperties;
+      const legacyProps = appDefWithAuth.legacy.searches.movie;
       legacyProps.resourceUrl = legacyProps.resourceUrl.replace(
         '/movie/',
         '/movies/'
@@ -1887,7 +1868,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_read_resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_read_resource_disabled',
         'movie_pre_read_resource'
       );
@@ -1910,13 +1891,12 @@ describe('Integration Test', () => {
 
     it('KEY_post_read_resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps =
-        appDefWithAuth.searches.movie.operation.legacyProperties;
+      const legacyProps = appDefWithAuth.legacy.searches.movie;
       legacyProps.resourceUrl = legacyProps.resourceUrl.replace(
         '/movie/',
         '/movies/'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_read_resource_disabled',
         'movie_post_read_resource'
       );
@@ -1943,11 +1923,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_read_resource & KEY_post_read_resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_read_resource_disabled',
         'movie_pre_read_resource'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_read_resource_disabled',
         'movie_post_read_resource'
       );
@@ -1974,7 +1954,7 @@ describe('Integration Test', () => {
 
     it('KEY_read_resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_read_resource_disabled',
         'movie_read_resource'
       );
@@ -1997,8 +1977,7 @@ describe('Integration Test', () => {
 
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.searches.movie.operation.legacyProperties.inputFieldsUrl +=
-        's';
+      appDefWithAuth.legacy.searches.movie.inputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -2018,7 +1997,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_search_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_search_fields_disabled',
         'movie_pre_custom_search_fields'
       );
@@ -2041,9 +2020,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_search_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.searches.movie.operation.legacyProperties.inputFieldsUrl +=
-        's';
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.searches.movie.inputFieldsUrl += 's';
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_search_fields_disabled',
         'movie_post_custom_search_fields'
       );
@@ -2068,11 +2046,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_search_fields & KEY_post_custom_search_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_search_fields_disabled',
         'movie_pre_custom_search_fields'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_search_fields_disabled',
         'movie_post_custom_search_fields'
       );
@@ -2097,7 +2075,7 @@ describe('Integration Test', () => {
 
     it('KEY_custom_search_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_custom_search_fields_disabled',
         'movie_custom_search_fields'
       );
@@ -2122,8 +2100,7 @@ describe('Integration Test', () => {
 
     it('scriptingless output fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.searches.movie.operation.legacyProperties.outputFieldsUrl +=
-        's';
+      appDefWithAuth.legacy.searches.movie.outputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -2147,7 +2124,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_search_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_search_result_fields_disabled',
         'movie_pre_custom_search_result_fields'
       );
@@ -2174,9 +2151,8 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_search_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.searches.movie.operation.legacyProperties.outputFieldsUrl +=
-        's';
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.searches.movie.outputFieldsUrl += 's';
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_search_result_fields_disabled',
         'movie_post_custom_search_result_fields'
       );
@@ -2205,11 +2181,11 @@ describe('Integration Test', () => {
 
     it('KEY_pre_custom_search_result_fields & KEY_post_custom_search_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_pre_custom_search_result_fields_disabled',
         'movie_pre_custom_search_result_fields'
       );
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_search_result_fields_disabled',
         'movie_post_custom_search_result_fields'
       );
@@ -2238,7 +2214,7 @@ describe('Integration Test', () => {
 
     it('KEY_custom_search_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacyScriptingSource = appDefWithAuth.legacyScriptingSource.replace(
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_custom_search_result_fields_disabled',
         'movie_custom_search_result_fields'
       );

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -142,7 +142,7 @@ describe('Integration Test', () => {
         'pre_oauthv2_token',
         'dont_care'
       );
-      appDefWithAuth.legacy.authentication.accessTokenUrl += 'token';
+      appDefWithAuth.legacy.authentication.oauth2Config.accessTokenUrl += 'token';
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
 
@@ -289,7 +289,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_trigger_fields', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.contact_full.outputFieldsUrl += 's';
+      appDef.legacy.triggers.contact_full.operation.outputFieldsUrl += 's';
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_full_pre_custom_trigger_fields',
         'contact_full_pre_custom_trigger_fields_disabled'
@@ -513,7 +513,7 @@ describe('Integration Test', () => {
       // Notication REST hook should fall back what REST Hook does when the
       // hook doesn't have resource_url
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.triggers.contact_hook_scripting.operation.hookType = 'notification';
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_catch_hook_returning_object',
         'contact_hook_scripting_catch_hook'
@@ -547,7 +547,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_hook', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.triggers.contact_hook_scripting.operation.hookType = 'notification';
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_pre_hook_disabled',
         'contact_hook_scripting_pre_hook'
@@ -577,7 +577,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_hook => object', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.triggers.contact_hook_scripting.operation.hookType = 'notification';
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_post_hook_returning_object',
         'contact_hook_scripting_post_hook'
@@ -608,7 +608,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_hook => array', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.triggers.contact_hook_scripting.operation.hookType = 'notification';
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_post_hook_returning_array',
         'contact_hook_scripting_post_hook'
@@ -641,7 +641,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_hook & KEY_post_hook => object', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.contact_hook_scripting.hookType = 'notification';
+      appDef.legacy.triggers.contact_hook_scripting.operation.hookType = 'notification';
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'contact_hook_scripting_pre_hook_disabled',
         'contact_hook_scripting_pre_hook'
@@ -719,7 +719,7 @@ describe('Integration Test', () => {
   describe('create', () => {
     it('scriptingless perform', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.url += 's';
+      appDefWithAuth.legacy.creates.movie.operation.url += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -743,7 +743,7 @@ describe('Integration Test', () => {
 
     it('scriptingless perform, curlies in URL', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps = appDefWithAuth.legacy.creates.movie;
+      const legacyProps = appDefWithAuth.legacy.creates.movie.operation;
       legacyProps.url = legacyProps.url.replace(
         '/movie',
         '/{{bundle.inputData.resource_name}}'
@@ -799,7 +799,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.url += 's';
+      appDefWithAuth.legacy.creates.movie.operation.url += 's';
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_write_disabled',
         'movie_post_write'
@@ -920,7 +920,7 @@ describe('Integration Test', () => {
         'movie_write_sync',
         'movie_write'
       );
-      const legacyProps = appDefWithAuth.legacy.creates.movie;
+      const legacyProps = appDefWithAuth.legacy.creates.movie.operation;
       legacyProps.url = legacyProps.url.replace(
         '/movie',
         '/{{bundle.inputData.resource_name}}'
@@ -950,7 +950,7 @@ describe('Integration Test', () => {
 
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.inputFieldsUrl += 's';
+      appDefWithAuth.legacy.creates.movie.operation.inputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -995,7 +995,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_action_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.inputFieldsUrl += 's';
+      appDefWithAuth.legacy.creates.movie.operation.inputFieldsUrl += 's';
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_action_fields_disabled',
         'movie_post_custom_action_fields'
@@ -1078,7 +1078,7 @@ describe('Integration Test', () => {
 
     it('scriptingless output fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.outputFieldsUrl += 's';
+      appDefWithAuth.legacy.creates.movie.operation.outputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -1129,7 +1129,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_action_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.outputFieldsUrl += 's';
+      appDefWithAuth.legacy.creates.movie.operation.outputFieldsUrl += 's';
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_action_result_fields_disabled',
         'movie_post_custom_action_result_fields'
@@ -1708,7 +1708,7 @@ describe('Integration Test', () => {
   describe('search', () => {
     it('scriptingless perform', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps = appDefWithAuth.legacy.searches.movie;
+      const legacyProps = appDefWithAuth.legacy.searches.movie.operation;
       legacyProps.url = legacyProps.url.replace('movie?', 'movies?');
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -1758,7 +1758,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_search', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps = appDefWithAuth.legacy.searches.movie;
+      const legacyProps = appDefWithAuth.legacy.searches.movie.operation;
       legacyProps.url = legacyProps.url.replace('movie?', 'movies?');
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_search_disabled',
@@ -1842,7 +1842,7 @@ describe('Integration Test', () => {
 
     it('scriptingless resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps = appDefWithAuth.legacy.searches.movie;
+      const legacyProps = appDefWithAuth.legacy.searches.movie.operation;
       legacyProps.resourceUrl = legacyProps.resourceUrl.replace(
         '/movie/',
         '/movies/'
@@ -1891,7 +1891,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_read_resource', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      const legacyProps = appDefWithAuth.legacy.searches.movie;
+      const legacyProps = appDefWithAuth.legacy.searches.movie.operation;
       legacyProps.resourceUrl = legacyProps.resourceUrl.replace(
         '/movie/',
         '/movies/'
@@ -1977,7 +1977,7 @@ describe('Integration Test', () => {
 
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.searches.movie.inputFieldsUrl += 's';
+      appDefWithAuth.legacy.searches.movie.operation.inputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -2020,7 +2020,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_search_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.searches.movie.inputFieldsUrl += 's';
+      appDefWithAuth.legacy.searches.movie.operation.inputFieldsUrl += 's';
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_search_fields_disabled',
         'movie_post_custom_search_fields'
@@ -2100,7 +2100,7 @@ describe('Integration Test', () => {
 
     it('scriptingless output fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.searches.movie.outputFieldsUrl += 's';
+      appDefWithAuth.legacy.searches.movie.operation.outputFieldsUrl += 's';
 
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -2151,7 +2151,7 @@ describe('Integration Test', () => {
 
     it('KEY_post_custom_search_result_fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.searches.movie.outputFieldsUrl += 's';
+      appDefWithAuth.legacy.searches.movie.operation.outputFieldsUrl += 's';
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'movie_post_custom_search_result_fields_disabled',
         'movie_post_custom_search_result_fields'


### PR DESCRIPTION
Addresses [PDE-538](https://zapierorg.atlassian.net/browse/PDE-538). Moves all the `legacyProperties` into a root prop `legacy` in the app definition. This requires https://github.com/zapier/zapier-platform-core/pull/132 to pass the tests.