### PR TITLE
Bypass trigger-has-id check

### DIFF
--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -218,6 +218,15 @@ const legacyScriptingSource = `
         });
       },
 
+      movie_post_poll_no_id: function(bundle) {
+        var movies = z.JSON.parse(bundle.response.content);
+        var url = '${AUTH_JSON_SERVER_URL}/movies';
+        return movies.map(movie => {
+          delete movie.id;
+          return movie;
+        });
+      },
+
       /*
        * Create/Action
        */
@@ -726,6 +735,17 @@ const MovieSearch = {
   }
 };
 
+const afterAppSource = `
+  if (Array.isArray(output.results)) {
+    output.results.forEach(result => {
+      if (typeof result.id === 'string' && result.id.startsWith('__TEMP_ID_REMOVE_ME_')) {
+        delete result.id;
+      }
+    });
+  }
+  return output;
+`;
+
 const App = {
   title: 'Example App',
   triggers: {
@@ -753,6 +773,12 @@ const App = {
       source: "return z.legacyScripting.run(bundle, 'hydrate.file');"
     }
   },
+  afterApp: [
+    {
+      args: ['output'],
+      source: afterAppSource
+    }
+  ],
   legacy: {
     scriptingSource: legacyScriptingSource,
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -247,6 +247,31 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_post_poll, no id', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_no_id',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then(output => {
+        const movies = output.results;
+        movies.length.should.greaterThan(1);
+        movies.forEach(movie => {
+          should.not.exist(movie.id);
+          should.exist(movie.title);
+        });
+      });
+    });
+
     it('KEY_pre_poll & KEY_post_poll', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
Fixes [PDE-559](https://zapierorg.atlassian.net/browse/PDE-559). To bypass the [trigger-has-id](https://github.com/zapier/zapier-platform-core/blob/07ce7227f1a6db0487992feabc260d7deea17484/src/checks/trigger-has-id.js) check, this PR uses a hack that adds `id` if the trigger results don't have one. This fake `id` will be removed by an `afterApp` middleware we generated for converted apps. See https://github.com/zapier/zapier/pull/22029 for the other side of work.