### PR TITLE
Use underscore instead of lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ const compileLegacyScriptingSource = (source, zcli, app) => {
     'InvalidSessionException',
     source + '\nreturn Zap;'
   )(
-    _,
+    require('underscore'),
     require('crypto'),
     require('async'),
     require('moment-timezone'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2278,6 +2278,11 @@
       "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
       "dev": true
     },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash": "4.17.10",
     "moment-timezone": "0.5.17",
     "request": "2.87.0",
+    "underscore": "1.4.4",
     "xmldom": "0.1.27"
   },
   "devDependencies": {

--- a/test/example-app/index.js
+++ b/test/example-app/index.js
@@ -241,6 +241,17 @@ const legacyScriptingSource = `
         });
       },
 
+      movie_post_poll_underscore: function(bundle) {
+        var movies = z.JSON.parse(bundle.response.content);
+
+        // _.collect is an alias of _.map in underscore, lodash doesn't have it
+        return _.collect(movies, function(movie, index) {
+          // lodash doesn't have _.contains, it only has _.includes
+          movie.titleHas2 = _.contains(movie.title, '2');
+          return movie;
+        });
+      },
+
       /*
        * Create/Action
        */

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -258,6 +258,11 @@ describe('Integration Test', () => {
     const app = createApp(appDefWithAuth);
 
     it('KEY_poll', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_no_id',
+        'movie_post_poll'
+      );
       const input = createTestInput(
         compiledApp,
         'triggers.contact_full.operation.perform'
@@ -272,6 +277,29 @@ describe('Integration Test', () => {
         const firstContact = output.results[0];
         should.equal(firstContact.name, 'Patched by KEY_poll!');
         should.equal(firstContact.zapTitle, 'My Awesome Zap');
+      });
+    });
+
+    it('KEY_poll, with underscore', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_underscore',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then(output => {
+        const movies = output.results;
+        movies[0].titleHas2.should.be.false();
+        movies[1].titleHas2.should.be.true();
+        movies[2].titleHas2.should.be.false();
       });
     });
 


### PR DESCRIPTION
Addresses [PDE-603](https://zapierorg.atlassian.net/browse/PDE-603), where we should use [Underscore](https://underscorejs.org/) instead of [Lodash](https://lodash.com/) for legacy scripting. 

Originally, to keep the package size small, I was thinking we can make an Underscore shim that calls Lodash under the hood. But it turned out adding an `underscore@1.4.4` dependency doesn't increase the size that much. Before and after are 3,459 and 3,477 KB, only a 0.5% increase.