### PR TITLE
Fix issue running polling triggers that double as auth tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -596,15 +596,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     });
   };
 
-  const isTestingAuth = (bundle, key) => {
-    const testTrigger = _.get(app, 'legacy.authentication.testTrigger');
-    if (testTrigger) {
-      if (key === testTrigger) {
-        return true;
-      }
-      return false;
-    }
-
+  const isTestingAuth = (bundle) => {
     // For core < 8.0.0
     if (
       _.get(bundle, 'meta.test_poll') === true &&
@@ -613,8 +605,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       return true;
     }
 
-    // For core >= 8.0.0. This could be inaccurate but it's unlikely to fall
-    // down here.
+    // For core >= 8.0.0
     return _.get(bundle, 'meta.isTestingAuth');
   };
 
@@ -623,7 +614,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     bundle.request.url = url;
 
     // For auth test we want to make sure we return an object instead of an array
-    const ensureType = isTestingAuth(bundle, key)
+    const ensureType = isTestingAuth(bundle)
       ? 'object-first'
       : 'array-first';
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -68,6 +68,12 @@ describe('Integration Test', () => {
         should.equal(output.results.key2, 'ret');
       });
     });
+  });
+
+  describe('authentication', () => {
+    const appDefWithAuth = withAuth(appDefinition, sessionAuthConfig);
+    const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+    const app = createApp(appDefWithAuth);
 
     it('get_connection_label', () => {
       const input = createTestInput(
@@ -79,25 +85,6 @@ describe('Integration Test', () => {
       };
       return app(input).then(output => {
         should.equal(output.results, 'Hi Mark');
-      });
-    });
-
-    it('authentication.test, test trigger info from definition', () => {
-      const _appDefWithAuth = withAuth(appDefinition, sessionAuthConfig);
-      _appDefWithAuth.legacy.authentication.testTrigger = 'contact_full';
-
-      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
-      const _app = createApp(_appDefWithAuth);
-
-      const input = createTestInput(_compiledApp, 'authentication.test');
-      input.bundle.authData = {
-        key1: 'sec',
-        key2: 'ret'
-      };
-      return _app(input).then(output => {
-        const user = output.results;
-        should.equal(user.id, 1);
-        should.equal(user.username, 'Bret');
       });
     });
 


### PR DESCRIPTION
## Description

Back in #42 we attempted to fix a bug where we wouldn't know for sure if we were doing an auth test or not. At the time, we assumed that if the trigger being run is the test trigger, it's an auth test.

This assumption doesn't hold, however. Some apps use a legitimate polling trigger as the auth test as well. In these situations, any Zap that tries to run with that trigger will return true for the `isTestingAuth` check [here](https://github.com/zapier/zapier-platform-legacy-scripting-runner/blob/40bfd4f922c1e476e460af64a4fe55149a42ca58/index.js#L716-L718), resulting in us plucking out the first item in the list. This in turns causes us to fail the middleware check for triggers returning an array.

This PR nukes the comparison against the test trigger key. We can make an improvement on the server side to have `bundle.meta.isTestingAuth` be accurate.